### PR TITLE
Add accounts and persistent saved games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 node_modules
 /dist
 
+# API secrets and local database (never commit these)
+/api/config.php
+/api/data/
+
 
 # local env files
 .env.local

--- a/README.md
+++ b/README.md
@@ -17,3 +17,24 @@ npm run build
 
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+## Accounts & saved games
+
+Each player has an account (email + password); their whole game is stored as one
+JSON blob and autosaved as they play. A small PHP + MySQL API under `api/` handles
+sign-in and load/save; the SPA talks to it same-origin, so login is a session
+cookie.
+
+### Running the API locally
+
+The API runs against SQLite locally, so no MySQL is needed:
+
+```
+cp api/config.sample.php api/config.php   # then set 'driver' => 'sqlite'
+php -S 127.0.0.1:8000 -t .                # serve the API on :8000
+npm run dev                                # Vite proxies /api to it
+```
+
+Open the Vite URL, create an account, and play — progress persists across
+reloads. In production, `api/config.php` uses the `mysql` driver and the tables
+in `api/schema.sql` are created once on the database.

--- a/api/_bootstrap.php
+++ b/api/_bootstrap.php
@@ -1,0 +1,107 @@
+<?php
+// Shared bootstrap for every API endpoint: database handle, session cookie, and
+// JSON request/response helpers. Same-origin with the SPA, so login is a plain
+// session cookie — no tokens, no CORS.
+
+declare(strict_types=1);
+
+$config = require __DIR__ . '/config.php';
+
+// Lazily-opened PDO handle. Driver-configurable so the same code runs against
+// MySQL in production and SQLite locally (the SQLite tables are created on the
+// fly; MySQL uses schema.sql, run once by hand).
+function db(): PDO
+{
+    static $pdo = null;
+    if ($pdo !== null) {
+        return $pdo;
+    }
+    global $config;
+
+    if (($config['driver'] ?? 'mysql') === 'sqlite') {
+        $dir = dirname($config['sqlite_path']);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+        $pdo = new PDO('sqlite:' . $config['sqlite_path']);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+        $pdo->exec('PRAGMA foreign_keys = ON');
+        $pdo->exec(
+            'CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime(\'now\'))
+            )'
+        );
+        $pdo->exec(
+            'CREATE TABLE IF NOT EXISTS saves (
+                user_id INTEGER PRIMARY KEY,
+                state TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            )'
+        );
+        return $pdo;
+    }
+
+    $dsn = sprintf(
+        'mysql:host=%s;dbname=%s;charset=%s',
+        $config['host'],
+        $config['name'],
+        $config['charset'] ?? 'utf8mb4'
+    );
+    $pdo = new PDO($dsn, $config['user'], $config['pass']);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+    return $pdo;
+}
+
+// Secure cookie only once we're actually on HTTPS, so local http development
+// (php -S) still keeps a session.
+$https = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+    || (($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https');
+session_set_cookie_params([
+    'lifetime' => 0,
+    'path' => '/',
+    'httponly' => true,
+    'secure' => $https,
+    'samesite' => 'Lax',
+]);
+session_name('FBSESS');
+session_start();
+
+function json_response(mixed $data, int $code = 200): never
+{
+    http_response_code($code);
+    header('Content-Type: application/json');
+    echo json_encode($data);
+    exit;
+}
+
+function json_input(): array
+{
+    $raw = file_get_contents('php://input');
+    if ($raw === '' || $raw === false) {
+        return [];
+    }
+    $data = json_decode($raw, true);
+    return is_array($data) ? $data : [];
+}
+
+function current_user_id(): ?int
+{
+    return isset($_SESSION['uid']) ? (int) $_SESSION['uid'] : null;
+}
+
+// Endpoints that need a logged-in user start with this; it ends the request
+// with 401 when there is none.
+function require_auth(): int
+{
+    $uid = current_user_id();
+    if ($uid === null) {
+        json_response(['error' => 'unauthorized'], 401);
+    }
+    return $uid;
+}

--- a/api/auth.php
+++ b/api/auth.php
@@ -1,0 +1,106 @@
+<?php
+// Account endpoints. Dispatched by ?action=register|login|logout|me.
+
+declare(strict_types=1);
+
+require __DIR__ . '/_bootstrap.php';
+
+$action = $_GET['action'] ?? '';
+
+switch ($action) {
+    case 'register':
+        register();
+        break;
+    case 'login':
+        login();
+        break;
+    case 'logout':
+        logout();
+        break;
+    case 'me':
+        me();
+        break;
+    default:
+        json_response(['error' => 'unknown_action'], 404);
+}
+
+function register(): never
+{
+    $in = json_input();
+    $email = strtolower(trim((string) ($in['email'] ?? '')));
+    $password = (string) ($in['password'] ?? '');
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        json_response(['error' => 'invalid_email'], 422);
+    }
+    if (strlen($password) < 8) {
+        json_response(['error' => 'weak_password'], 422);
+    }
+
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT id FROM users WHERE email = ?');
+    $stmt->execute([$email]);
+    if ($stmt->fetch()) {
+        json_response(['error' => 'email_taken'], 409);
+    }
+
+    $hash = password_hash($password, PASSWORD_DEFAULT);
+    $stmt = $pdo->prepare('INSERT INTO users (email, password_hash) VALUES (?, ?)');
+    $stmt->execute([$email, $hash]);
+    $uid = (int) $pdo->lastInsertId();
+
+    session_regenerate_id(true);
+    $_SESSION['uid'] = $uid;
+    json_response(['user' => ['id' => $uid, 'email' => $email]]);
+}
+
+function login(): never
+{
+    $in = json_input();
+    $email = strtolower(trim((string) ($in['email'] ?? '')));
+    $password = (string) ($in['password'] ?? '');
+
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT id, password_hash FROM users WHERE email = ?');
+    $stmt->execute([$email]);
+    $row = $stmt->fetch();
+
+    if (!$row || !password_verify($password, $row['password_hash'])) {
+        json_response(['error' => 'invalid_credentials'], 401);
+    }
+
+    session_regenerate_id(true);
+    $_SESSION['uid'] = (int) $row['id'];
+    json_response(['user' => ['id' => (int) $row['id'], 'email' => $email]]);
+}
+
+function logout(): never
+{
+    $_SESSION = [];
+    if (ini_get('session.use_cookies')) {
+        $p = session_get_cookie_params();
+        setcookie(session_name(), '', [
+            'expires' => time() - 42000,
+            'path' => $p['path'],
+            'domain' => $p['domain'],
+            'secure' => $p['secure'],
+            'httponly' => $p['httponly'],
+            'samesite' => $p['samesite'] ?? 'Lax',
+        ]);
+    }
+    session_destroy();
+    json_response(['ok' => true]);
+}
+
+function me(): never
+{
+    $uid = current_user_id();
+    if ($uid === null) {
+        json_response(['user' => null]);
+    }
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT id, email FROM users WHERE id = ?');
+    $stmt->execute([$uid]);
+    $row = $stmt->fetch();
+    json_response(['user' => $row ? ['id' => (int) $row['id'], 'email' => $row['email']] : null]);
+}

--- a/api/config.sample.php
+++ b/api/config.sample.php
@@ -1,0 +1,19 @@
+<?php
+// Copy this file to config.php and fill in your database credentials. config.php
+// is git-ignored and must be uploaded to the server once, by hand — deploys
+// never touch it.
+
+return [
+    // 'mysql' in production, 'sqlite' for local development/tests.
+    'driver' => 'mysql',
+
+    // --- MySQL (production) ---
+    'host' => 'localhost',
+    'name' => 'your_database',
+    'user' => 'your_db_user',
+    'pass' => 'your_db_password',
+    'charset' => 'utf8mb4',
+
+    // --- SQLite (local only) ---
+    'sqlite_path' => __DIR__ . '/data/football.sqlite',
+];

--- a/api/save.php
+++ b/api/save.php
@@ -1,0 +1,46 @@
+<?php
+// The logged-in user's single saved game. GET loads it, PUT replaces it.
+
+declare(strict_types=1);
+
+require __DIR__ . '/_bootstrap.php';
+
+$uid = require_auth();
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT state FROM saves WHERE user_id = ?');
+    $stmt->execute([$uid]);
+    $row = $stmt->fetch();
+    json_response(['state' => $row ? json_decode($row['state'], true) : null]);
+}
+
+if ($method === 'PUT') {
+    $raw = file_get_contents('php://input');
+    if ($raw === false || strlen($raw) > 4 * 1024 * 1024) {
+        json_response(['error' => 'too_large'], 413);
+    }
+    $in = json_decode($raw, true);
+    if (!is_array($in) || !array_key_exists('state', $in)) {
+        json_response(['error' => 'bad_request'], 422);
+    }
+
+    $state = json_encode($in['state']);
+    $now = gmdate('Y-m-d H:i:s');
+    $pdo = db();
+
+    // Portable upsert (works on both MySQL and SQLite).
+    $stmt = $pdo->prepare('SELECT 1 FROM saves WHERE user_id = ?');
+    $stmt->execute([$uid]);
+    if ($stmt->fetch()) {
+        $stmt = $pdo->prepare('UPDATE saves SET state = ?, updated_at = ? WHERE user_id = ?');
+        $stmt->execute([$state, $now, $uid]);
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO saves (user_id, state, updated_at) VALUES (?, ?, ?)');
+        $stmt->execute([$uid, $state, $now]);
+    }
+    json_response(['ok' => true, 'updated_at' => $now]);
+}
+
+json_response(['error' => 'method_not_allowed'], 405);

--- a/api/schema.sql
+++ b/api/schema.sql
@@ -1,0 +1,17 @@
+-- Run once on the production MySQL database (e.g. in phpMyAdmin). The local
+-- SQLite database is created automatically by _bootstrap.php.
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- One save per user: the whole game state as a JSON blob.
+CREATE TABLE IF NOT EXISTS saves (
+    user_id INT NOT NULL PRIMARY KEY,
+    state LONGTEXT NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_saves_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/assets/js/api.js
+++ b/src/assets/js/api.js
@@ -1,0 +1,34 @@
+// Same-origin client for the PHP API. The session cookie rides along on every
+// request; in development Vite proxies /api to the local php -S server.
+
+function options(method, body) {
+  return {
+    method,
+    credentials: 'same-origin',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  };
+}
+
+async function request(url, method, body) {
+  const res = await fetch(url, options(method, body));
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw Object.assign(new Error(data.error || res.statusText), {
+      status: res.status,
+      code: data.error,
+    });
+  }
+  return data;
+}
+
+export const api = {
+  register: (email, password) =>
+    request('/api/auth.php?action=register', 'POST', { email, password }),
+  login: (email, password) =>
+    request('/api/auth.php?action=login', 'POST', { email, password }),
+  logout: () => request('/api/auth.php?action=logout', 'POST'),
+  me: () => request('/api/auth.php?action=me', 'GET'),
+  loadSave: () => request('/api/save.php', 'GET'),
+  putSave: (state) => request('/api/save.php', 'PUT', { state }),
+};

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -8,6 +8,7 @@
           <span class="balance">{{ balance }}</span>
         </div>
         <button class="restart-btn" title="Restart" aria-label="Restart" @click="restartGame">↻</button>
+        <button class="restart-btn" :title="`Sign out (${userEmail})`" aria-label="Sign out" @click="logout">⎋</button>
       </div>
 
       <div class="nav-links">
@@ -34,6 +35,8 @@ export default {
 
   components: { ClubCrest },
 
+  inject: ['persistence'],
+
   emits: ['advance-week'],
 
   computed: {
@@ -41,15 +44,27 @@ export default {
     crest() { return this.$store.state.club.crest },
     balance() { return moneyStr(this.$store.state.club.money) + ' €' },
     week() { return this.$store.state.club.week },
+    userEmail() { return this.$store.state.auth.user?.email ?? '' },
     // A week the manager watches their own match advances into the match screen
     // rather than straight to the next week, so the CTA names that.
     advanceLabel() { return this.$store.getters.currentMatch ? 'Next Match' : 'Next Week' },
   },
 
   methods: {
-    // TODO: temporary — full reload wipes the in-memory store and starts a fresh draft
+    // Wipe the current game back to a fresh slate and reopen the draft. The next
+    // pick autosaves over the old save. (No reload — that would just re-hydrate
+    // the saved game and bounce back to the team.)
     restartGame() {
-      window.location.assign('/');
+      this.persistence.reset();
+      this.$router.push({ name: 'Draft' });
+    },
+
+    // End the session: clear the user, stop autosaving, and wipe the game so the
+    // next account on this browser starts clean.
+    async logout() {
+      await this.$store.dispatch('auth/logout');
+      this.persistence.end();
+      this.$router.replace({ name: 'Login' });
     },
 
     // App orchestrates the week transition and commits the store change at the

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -59,11 +59,12 @@ export default {
       this.$router.push({ name: 'Draft' });
     },
 
-    // End the session: clear the user, stop autosaving, and wipe the game so the
-    // next account on this browser starts clean.
+    // End the session. Flush any pending save and wipe the local game *first*
+    // (while the session cookie is still valid), then clear the session
+    // server-side. The saved game stays in the account and reloads on next login.
     async logout() {
+      await this.persistence.end();
       await this.$store.dispatch('auth/logout');
-      this.persistence.end();
       this.$router.replace({ name: 'Login' });
     },
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,5 +2,30 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import store from './store'
+import { createPersistence } from './store/persistence'
 
-createApp(App).use(store).use(router).mount('#app')
+const app = createApp(App).use(store)
+
+// One persistence controller for the whole app, shared with the views that
+// start/end a session (Login, Navigation) via inject.
+const persistence = createPersistence(store)
+app.provide('persistence', persistence)
+
+// Resolve who is logged in (and load their save) before installing the router,
+// so its initial navigation and guard see real auth state. Installing the
+// router any earlier kicks off that first navigation before auth is known and
+// strands the user on /login.
+async function boot() {
+  try {
+    await store.dispatch('auth/fetchMe')
+    if (store.getters['auth/isAuthenticated']) {
+      await persistence.resume()
+    }
+  } catch (e) {
+    // API unreachable — fall through to the login screen.
+  }
+  app.use(router)
+  app.mount('#app')
+}
+
+boot()

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,14 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import store from '../store'
 
 const routes = [
+  {
+    // The sign-in / create-account screen; the only route reachable signed out.
+    path: '/login',
+    name: 'Login',
+    meta: { public: true },
+    component: () => import('../views/Login.vue')
+  },
   {
     path: '/',
     name: 'Draft',
@@ -48,6 +56,16 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes
+})
+
+// Everything but the login screen needs an account. The initial /me check has
+// already resolved before the app mounts, so the guard sees real auth state.
+router.beforeEach((to) => {
+  const authed = store.getters['auth/isAuthenticated']
+  if (to.meta.public) {
+    return authed ? { name: 'Draft' } : true
+  }
+  return authed ? true : { name: 'Login' }
 })
 
 export default router

--- a/src/store/Auth.js
+++ b/src/store/Auth.js
@@ -1,0 +1,50 @@
+import { api } from '@/assets/js/api.js';
+
+// Who is logged in. Namespaced so its mutations stay clear of the game modules
+// (and so persistence can skip auth/* mutations when deciding to autosave).
+export const authModule = {
+  namespaced: true,
+
+  state: {
+    user: null,
+    // True once the initial /me check has resolved, so the router guard waits
+    // for a real answer instead of bouncing to /login on first load.
+    ready: false,
+  },
+
+  getters: {
+    isAuthenticated: (state) => !!state.user,
+  },
+
+  mutations: {
+    SET_USER(state, user) {
+      state.user = user;
+    },
+    SET_READY(state, ready) {
+      state.ready = ready;
+    },
+  },
+
+  actions: {
+    async fetchMe({ commit }) {
+      const { user } = await api.me();
+      commit('SET_USER', user);
+      commit('SET_READY', true);
+      return user;
+    },
+    async register({ commit }, { email, password }) {
+      const { user } = await api.register(email, password);
+      commit('SET_USER', user);
+      return user;
+    },
+    async login({ commit }, { email, password }) {
+      const { user } = await api.login(email, password);
+      commit('SET_USER', user);
+      return user;
+    },
+    async logout({ commit }) {
+      await api.logout();
+      commit('SET_USER', null);
+    },
+  },
+};

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import { teamModule } from './Team'
 import { draftModule } from './Draft'
 import { leagueModule } from './League'
 import { transferMarketModule } from './TransferMarket'
+import { authModule } from './Auth'
 
 export default createStore({
   modules: {
@@ -12,5 +13,6 @@ export default createStore({
     draft: draftModule,
     league: leagueModule,
     transferMarket: transferMarketModule,
+    auth: authModule,
   }
 })

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -60,16 +60,20 @@ export function createPersistence(store) {
       enabled = true;
       return !!state;
     },
-    // Discard the in-memory game (back to the new-game baseline).
+    // Discard the in-memory game (back to the new-game baseline). The save on
+    // the server is untouched — it's reloaded on the next login.
     reset() {
       replaceGame(clone(initial));
     },
-    // Stop autosaving and wipe the game — used on logout.
-    end() {
+    // Logout: stop autosaving, persist any change still inside the debounce
+    // window (so nothing recent is lost), then wipe the local game. Must run
+    // while the session is still valid, i.e. before clearing it server-side.
+    async end() {
       enabled = false;
       if (timer) {
         clearTimeout(timer);
         timer = null;
+        await flush();
       }
       controller.reset();
     },

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -1,0 +1,79 @@
+import { api } from '@/assets/js/api.js';
+
+// The game modules that make up a save. `auth` is deliberately excluded.
+const GAME_MODULES = ['club', 'team', 'draft', 'league', 'transferMarket'];
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+// Owns the save lifecycle: hydrate the store from the server on login, autosave
+// game changes (debounced), and wipe back to a pristine game on logout so a
+// second account on the same browser never inherits the first one's squad.
+export function createPersistence(store) {
+  // The untouched game state captured before any hydration — the "new game"
+  // baseline we restore on logout and reset.
+  const initial = {};
+  for (const module of GAME_MODULES) initial[module] = clone(store.state[module]);
+
+  let enabled = false;
+  let timer = null;
+
+  const snapshot = () => {
+    const out = {};
+    for (const module of GAME_MODULES) out[module] = store.state[module];
+    return out;
+  };
+
+  // replaceState swaps the whole tree, so keep auth and overwrite only the game
+  // modules. replaceState does not fire subscribers, so this never autosaves.
+  const replaceGame = (modules) => {
+    const merged = { ...store.state };
+    for (const module of GAME_MODULES) {
+      if (modules[module] !== undefined) merged[module] = modules[module];
+    }
+    store.replaceState(merged);
+  };
+
+  const flush = async () => {
+    timer = null;
+    try {
+      await api.putSave(snapshot());
+    } catch (e) {
+      // Offline or session expired — the next mutation reschedules a save.
+    }
+  };
+
+  store.subscribe((mutation) => {
+    if (!enabled || mutation.type.startsWith('auth/')) return;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(flush, 1500);
+  });
+
+  const controller = {
+    // Load the user's save and start autosaving. Returns whether a saved game
+    // existed (false = brand-new account, which then runs the draft).
+    async resume() {
+      const { state } = await api.loadSave();
+      if (state) {
+        replaceGame(state);
+      } else {
+        controller.reset();
+      }
+      enabled = true;
+      return !!state;
+    },
+    // Discard the in-memory game (back to the new-game baseline).
+    reset() {
+      replaceGame(clone(initial));
+    },
+    // Stop autosaving and wipe the game — used on logout.
+    end() {
+      enabled = false;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      controller.reset();
+    },
+  };
+
+  return controller;
+}

--- a/src/views/Draft.vue
+++ b/src/views/Draft.vue
@@ -30,7 +30,11 @@ export default {
       this.$router.replace({ name: 'Team' });
       return;
     }
-    this.$store.dispatch('makeLeague');
+    // Only build the league for a brand-new game. A reload mid-draft has the
+    // league restored from the save already; re-running would regenerate it.
+    if (!this.$store.state.league.clubs.length) {
+      this.$store.dispatch('makeLeague');
+    }
   },
 
   computed: {

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="auth-page">
+    <form class="card auth-card" @submit.prevent="submit">
+      <h1 class="headline auth-title">{{ isRegister ? 'Create account' : 'Sign in' }}</h1>
+
+      <label class="field">
+        <span class="field-label">Email</span>
+        <input
+          v-model="email"
+          type="email"
+          autocomplete="email"
+          required
+          class="field-input"
+        />
+      </label>
+
+      <label class="field">
+        <span class="field-label">Password</span>
+        <input
+          v-model="password"
+          type="password"
+          :autocomplete="isRegister ? 'new-password' : 'current-password'"
+          required
+          class="field-input"
+        />
+      </label>
+
+      <p v-if="error" class="auth-error">{{ error }}</p>
+
+      <Button class="auth-submit" type="submit" :disabled="busy">
+        {{ busy ? 'Please wait…' : (isRegister ? 'Create account' : 'Sign in') }}
+      </Button>
+
+      <button type="button" class="auth-toggle" @click="toggleMode">
+        {{ isRegister ? 'Have an account? Sign in' : 'Need an account? Create one' }}
+      </button>
+    </form>
+  </div>
+</template>
+
+<script>
+import Button from '@/components/Button.vue';
+
+const MESSAGES = {
+  invalid_email: 'Please enter a valid email address.',
+  weak_password: 'Password must be at least 8 characters.',
+  email_taken: 'That email is already registered.',
+  invalid_credentials: 'Wrong email or password.',
+};
+
+export default {
+  name: 'Login',
+
+  components: { Button },
+
+  inject: ['persistence'],
+
+  data() {
+    return {
+      mode: 'login',
+      email: '',
+      password: '',
+      error: '',
+      busy: false,
+    };
+  },
+
+  computed: {
+    isRegister() {
+      return this.mode === 'register';
+    },
+  },
+
+  methods: {
+    toggleMode() {
+      this.mode = this.isRegister ? 'login' : 'register';
+      this.error = '';
+    },
+
+    async submit() {
+      if (this.busy) return;
+      this.busy = true;
+      this.error = '';
+      try {
+        const action = this.isRegister ? 'auth/register' : 'auth/login';
+        await this.$store.dispatch(action, { email: this.email, password: this.password });
+        await this.persistence.resume();
+        // Draft.vue forwards a returning manager to the team once the squad is
+        // complete, so we can always land on the start route.
+        this.$router.replace({ name: 'Draft' });
+      } catch (e) {
+        this.error = MESSAGES[e.code] || 'Something went wrong. Please try again.';
+        this.busy = false;
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.auth-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 24px;
+}
+
+.auth-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  max-width: 360px;
+  text-align: left;
+}
+
+.auth-title {
+  font-size: 28px;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: $col_text_faded;
+}
+
+.field-input {
+  padding: 10px 12px;
+  border: 1px solid $col_module_background_faded;
+  border-radius: 8px;
+  background-color: $col_page_background;
+  color: $col_text;
+  font-family: inherit;
+  font-size: 15px;
+}
+
+.field-input:focus {
+  outline: none;
+  border-color: $col_text_faded;
+}
+
+.auth-error {
+  color: #e5534b;
+  font-size: 13px;
+}
+
+.auth-submit {
+  align-self: stretch;
+  border-color: $col_module_background_faded;
+}
+
+.auth-submit:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.auth-toggle {
+  background: none;
+  border: none;
+  color: $col_text_faded;
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.auth-toggle:hover {
+  color: $col_text;
+}
+</style>

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -22,6 +22,16 @@ export default defineConfig({
     }
   },
   server: {
-    port: Number(process.env.PORT) || 8080
+    port: Number(process.env.PORT) || 8080,
+    // In development the SPA runs on Vite and the PHP API on `php -S`; this
+    // forwards /api to it so the browser sees one same-origin server (and the
+    // session cookie just works). In production both are served from the
+    // webspace, so this proxy is dev-only.
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true
+      }
+    }
   }
 })


### PR DESCRIPTION
## What & why

PR 1 of 2 toward *persistent data + deployment*. This adds **user accounts** and **persistent saved games**. Today the whole game lives in the Vuex store in memory, so a refresh wipes it. Now each player signs in (email + password) and their entire game is stored server-side as one JSON blob and autosaved as they play.

Single-player game ⇒ no normalized schema: one save row per user, loaded on login and saved (debounced) on change.

## Backend — `api/` (PHP + MySQL; SQLite locally)
- `_bootstrap.php` — PDO handle (driver-configurable), secure session cookie (`httpOnly`, `Secure`, `SameSite=Lax`), JSON helpers, auth guard
- `auth.php` — `register` / `login` / `logout` / `me` with `password_hash` + prepared statements + input validation
- `save.php` — `GET` loads / `PUT` replaces the user's save, auth-guarded, body-size cap
- `schema.sql` — `users` + `saves` (run once on the prod DB)
- `config.sample.php` — copy to `config.php` (git-ignored; uploaded once, never deployed)

Same-origin with the SPA, so login is a plain session cookie — no tokens, no CORS.

## Frontend
- `assets/js/api.js` client + namespaced Vuex `auth` module
- `store/persistence.js` — hydrate on login, debounced autosave, **wipe to a pristine game on logout** so a second account on the same browser can't inherit the first one's squad
- `views/Login.vue` (sign-in / create-account toggle) + auth router guard
- `main.js` installs the router **after** the initial `/me` check, so the first navigation sees real auth state (otherwise it strands you on `/login`)
- `Navigation.vue` — sign-out control; "restart" now resets the save instead of doing a full reload
- `Draft.vue` — only builds the league for a brand-new game, not on a mid-draft reload (it's now restored from the save)

## Verified locally (PHP 8.4 + SQLite, browser-driven)
- Register → clean draft; autosave wrote the full 280 KB state (squad + 17 AI clubs + fixtures)
- Reload → stayed logged in, game restored, landed on the right screen
- Logout → session cleared, local game wiped, redirect to `/login`
- Two accounts → fully isolated saves in the DB (user 1's 3 players untouched while user 2 started at 0)
- API edge cases: duplicate email (409), wrong password (401), weak password (422)

## Note for the reviewer
A small auth UI deviation from the plan: one Login screen with a sign-in/create-account toggle instead of two separate pages (less duplication; same capability). Deployment (`.htaccess`, CI push-to-deploy, docs) is **PR 2**.