### PR TITLE
Fix API 500: run on older PHP + tolerate host:port

### DIFF
--- a/api/_bootstrap.php
+++ b/api/_bootstrap.php
@@ -46,9 +46,17 @@ function db(): PDO
         return $pdo;
     }
 
+    // Accept 'host' => 'db.example' (with an optional separate 'port'), or a
+    // combined 'host:port' string (a common copy-paste from control panels).
+    $host = $config['host'];
+    $port = $config['port'] ?? null;
+    if (strpos($host, ':') !== false) {
+        list($host, $port) = explode(':', $host, 2);
+    }
     $dsn = sprintf(
-        'mysql:host=%s;dbname=%s;charset=%s',
-        $config['host'],
+        'mysql:host=%s;%sdbname=%s;charset=%s',
+        $host,
+        $port ? 'port=' . $port . ';' : '',
         $config['name'],
         $config['charset'] ?? 'utf8mb4'
     );
@@ -72,7 +80,7 @@ session_set_cookie_params([
 session_name('FBSESS');
 session_start();
 
-function json_response(mixed $data, int $code = 200): never
+function json_response($data, $code = 200)
 {
     http_response_code($code);
     header('Content-Type: application/json');

--- a/api/auth.php
+++ b/api/auth.php
@@ -24,7 +24,7 @@ switch ($action) {
         json_response(['error' => 'unknown_action'], 404);
 }
 
-function register(): never
+function register()
 {
     $in = json_input();
     $email = strtolower(trim((string) ($in['email'] ?? '')));
@@ -54,7 +54,7 @@ function register(): never
     json_response(['user' => ['id' => $uid, 'email' => $email]]);
 }
 
-function login(): never
+function login()
 {
     $in = json_input();
     $email = strtolower(trim((string) ($in['email'] ?? '')));
@@ -74,7 +74,7 @@ function login(): never
     json_response(['user' => ['id' => (int) $row['id'], 'email' => $email]]);
 }
 
-function logout(): never
+function logout()
 {
     $_SESSION = [];
     if (ini_get('session.use_cookies')) {
@@ -92,7 +92,7 @@ function logout(): never
     json_response(['ok' => true]);
 }
 
-function me(): never
+function me()
 {
     $uid = current_user_id();
     if ($uid === null) {


### PR DESCRIPTION
Production returned **500 on every API endpoint** — including `?action=me`, which never touches the DB — so the PHP failed to parse. Root cause: `mixed`/`never` type hints (PHP 8.0/8.1+) while the host serves this folder with an older PHP.

- Remove the `mixed`/`never` hints (no runtime effect) → API parses on **PHP 7.3+**.
- Split a combined `host:port` config value (e.g. `localhost:3306`) into DSN host + port, so the value already uploaded works without re-editing.

Verified on PHP: register/login/me/save round-trip; the no-session `me` that was 500ing now returns `{"user":null}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)