### PR TITLE
Fix API 500 on old PHP + add temporary diagnostic

### DIFF
--- a/api/_bootstrap.php
+++ b/api/_bootstrap.php
@@ -70,13 +70,19 @@ function db(): PDO
 // (php -S) still keeps a session.
 $https = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
     || (($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https');
-session_set_cookie_params([
-    'lifetime' => 0,
-    'path' => '/',
-    'httponly' => true,
-    'secure' => $https,
-    'samesite' => 'Lax',
-]);
+if (PHP_VERSION_ID >= 70300) {
+    // PHP 7.3+ supports the array form (and the SameSite attribute).
+    session_set_cookie_params([
+        'lifetime' => 0,
+        'path' => '/',
+        'httponly' => true,
+        'secure' => $https,
+        'samesite' => 'Lax',
+    ]);
+} else {
+    // Older PHP: positional args only (no SameSite).
+    session_set_cookie_params(0, '/', '', $https, true);
+}
 session_name('FBSESS');
 session_start();
 
@@ -98,7 +104,7 @@ function json_input(): array
     return is_array($data) ? $data : [];
 }
 
-function current_user_id(): ?int
+function current_user_id()
 {
     return isset($_SESSION['uid']) ? (int) $_SESSION['uid'] : null;
 }

--- a/api/auth.php
+++ b/api/auth.php
@@ -79,14 +79,18 @@ function logout()
     $_SESSION = [];
     if (ini_get('session.use_cookies')) {
         $p = session_get_cookie_params();
-        setcookie(session_name(), '', [
-            'expires' => time() - 42000,
-            'path' => $p['path'],
-            'domain' => $p['domain'],
-            'secure' => $p['secure'],
-            'httponly' => $p['httponly'],
-            'samesite' => $p['samesite'] ?? 'Lax',
-        ]);
+        if (PHP_VERSION_ID >= 70300) {
+            setcookie(session_name(), '', [
+                'expires' => time() - 42000,
+                'path' => $p['path'],
+                'domain' => $p['domain'],
+                'secure' => $p['secure'],
+                'httponly' => $p['httponly'],
+                'samesite' => isset($p['samesite']) ? $p['samesite'] : 'Lax',
+            ]);
+        } else {
+            setcookie(session_name(), '', time() - 42000, $p['path'], $p['domain'], $p['secure'], $p['httponly']);
+        }
     }
     session_destroy();
     json_response(['ok' => true]);

--- a/api/diag.php
+++ b/api/diag.php
@@ -1,0 +1,25 @@
+<?php
+// TEMPORARY diagnostic — remove after debugging. Reports the server runtime so
+// we can see why the API 500s. Prints no secrets (a DB error may name the host/
+// user, never the password). Delete this file once the API works.
+
+header('Content-Type: text/plain; charset=utf-8');
+
+echo 'PHP ' . PHP_VERSION . "\n";
+echo 'pdo_mysql loaded: ' . (extension_loaded('pdo_mysql') ? 'yes' : 'NO') . "\n";
+echo 'config.php present: ' . (file_exists(__DIR__ . '/config.php') ? 'yes' : 'NO') . "\n";
+echo "--- include _bootstrap.php ---\n";
+
+try {
+    require __DIR__ . '/_bootstrap.php';
+    echo "bootstrap: OK\n";
+    try {
+        db();
+        echo "db connect: OK\n";
+    } catch (Throwable $e) {
+        echo 'db connect ERROR: ' . $e->getMessage() . "\n";
+    }
+} catch (Throwable $e) {
+    echo 'bootstrap ERROR: ' . get_class($e) . ': ' . $e->getMessage()
+        . ' @ ' . basename($e->getFile()) . ':' . $e->getLine() . "\n";
+}


### PR DESCRIPTION
Follow-up to #10. The type-hint fix deployed but `/me` still 500'd — and `/me` never touches the DB, so the host runs an older PHP that rejects the **array forms** of `session_set_cookie_params()`/`setcookie()` (PHP 7.3+).

- Version-guard both (positional fallback on older PHP); drop the `?int` hint. API now runs on **PHP 7.0+**.
- Add **temporary** `api/diag.php` that prints the PHP version + any real error as plain text, so we get ground truth if it still fails. To be removed once it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)