### PR TITLE
Continuous, performance-driven player development

### DIFF
--- a/src/assets/js/Config.js
+++ b/src/assets/js/Config.js
@@ -13,6 +13,38 @@ export const PLAYER_OPTAGE_MIN = 28;
 export const PLAYER_OPTAGE_MAX = 31;
 export const AGE_FACTOR = .95;
 
+// --- Continuous player development (applied every week) -----------------
+// Each week a player's skill chases its natural age-curve value (projectedSkill,
+// the "target"); match weeks add a performance push, and the potential (ceiling)
+// drifts slowly. See HLP.developPlayers. Steps are tiny because they apply ~52x
+// per season (34 match weeks + ~18 training weeks).
+//
+// DEV_BASELINE is the empirical mean match rating per role, measured from a
+// no-development league sim (overall ~6.27, attackers ~6.71 vs defenders ~6.10).
+// Performance is `rating - DEV_BASELINE[role]`, so the push is league-wide
+// zero-sum and the flat 6.0 baseline's positive/attacking bias is removed.
+export const DEV_BASELINE = { GK: 6.15, DEF: 6.10, MID: 6.28, ATT: 6.71 };
+export const DEV_CONVERGE = 0.05;        // fraction of the gap to target closed per week (natural growth)
+export const DEV_PERF_RATE = 0.10;       // skill push per (rating point over baseline) on a match week
+export const DEV_PERF_CAP = 2.0;         // clamp rating-baseline to +/- this
+export const DEV_TRAIN_WEIGHT = 0.3;     // convergence weight for bench/reserve (no minutes)
+export const DEV_POT_RATE = 0.045;       // potential drift per (rating point over baseline) on a match week
+export const DEV_POT_REVERSION = 0.012;  // weekly pull of potential back toward its drawn value
+
+// Skill-change column in the squad list: the timeframe the change is measured
+// over, chosen from the list header's flyout. "Last N weeks" reads a rolling
+// per-player weekly skill log (kept DEV_HISTORY_WEEKS long, the longest window);
+// "This season" and "Since joining" read the seasonStartSkill / joinSkill marks.
+export const DEV_TIMEFRAMES = [
+  { key: 'w5', label: 'Last 5 weeks', weeks: 5 },
+  { key: 'w10', label: 'Last 10 weeks', weeks: 10 },
+  { key: 'w20', label: 'Last 20 weeks', weeks: 20 },
+  { key: 'season', label: 'This season' },
+  { key: 'join', label: 'Since joining my club' },
+];
+export const DEV_HISTORY_WEEKS = 20;
+export const DEV_DEFAULT_TIMEFRAME = 'season';
+
 // Salary: SALARY_BASE is the pay of an average player (skill =
 // DRAFT_AVG_POTENTIAL), raised superlinearly so stars demand disproportionate
 // pay — flatter than MV_EXPONENT, so salaries spread less than prices. Greed

--- a/src/assets/js/Helpers.js
+++ b/src/assets/js/Helpers.js
@@ -50,16 +50,89 @@ export function projectedSkill(player, years) {
   return Math.floor(player.potential * Math.pow(CFG.AGE_FACTOR, distance));
 }
 
-// Ages a player by one year (season change): the skill follows the development
-// curve (projectedSkill one year out) and the stat profile scales with it.
+// Ages a player by one year, on his birthday week. Skill is no longer snapped to
+// the age curve here — continuous weekly development (developPlayers) tracks it;
+// aging just shifts the curve target a year older, which development then chases.
 export function agePlayer(player) {
-  const newSkill = projectedSkill(player, 1);
-  const factor = player.skill > 0 ? newSkill / player.skill : 0;
-  for (const key of Object.keys(player.skills)) {
-    player.skills[key] = Math.round(player.skills[key] * factor);
-  }
   player.age += 1;
+}
+
+const clamp = (x, lo, hi) => Math.max(lo, Math.min(hi, x));
+
+// Applies a fractional skill value to a player. The exact value lives in
+// `skillExact` so the tiny weekly development steps accumulate instead of
+// rounding away, while the integer `skill` (read everywhere else) and the stat
+// profile (read by the match engine) follow it rounded to whole numbers.
+function setSkill(player, exact) {
+  player.skillExact = exact;
+  const newSkill = Math.round(exact);
+  if (player.skills) {
+    const sum = Object.values(player.skills).reduce((s, v) => s + v, 0);
+    if (sum > 0) {
+      const factor = newSkill / sum;
+      for (const key of Object.keys(player.skills)) player.skills[key] = Math.round(player.skills[key] * factor);
+    }
+  }
   player.skill = newSkill;
+}
+
+// Develops a whole squad for one week from a matchday ratings map
+// ({ [playerId]: rating }, empty in training/match-free weeks). For every player:
+//  - skill chases its natural age-curve value (training/aging) — applies to all,
+//    bench/reserve at DEV_TRAIN_WEIGHT;
+//  - a player who featured gets a performance push of (rating - role baseline):
+//    above the role's empirical mean pushes skill over the curve and drifts
+//    potential up, below pushes them down;
+//  - potential reverts gently toward its drawn value (bounds long-run drift).
+// All bounded to [0, 100]. Shared by the team and league APPLY/DEVELOP paths so
+// the own squad and every AI club develop identically.
+export function developPlayers(players, ratings = {}) {
+  for (const player of players) {
+    if (player.drawnPotential == null) player.drawnPotential = player.potential;
+    if (player.skillExact == null) player.skillExact = player.skill;
+    const rating = ratings[player.id];
+    const played = rating != null;
+    const weight = played ? 1 : CFG.DEV_TRAIN_WEIGHT;
+
+    // Convergence toward the natural curve (training / aging) for everyone.
+    let delta = (projectedSkill(player, 0) - player.skillExact) * CFG.DEV_CONVERGE * weight;
+
+    if (played) {
+      const role = CFG.POSITION_ROLE[player.positions.position] || 'MID';
+      const baseline = CFG.DEV_BASELINE[role] ?? CFG.MATCH_RATING_BASE;
+      const perf = clamp(rating - baseline, -CFG.DEV_PERF_CAP, CFG.DEV_PERF_CAP);
+      delta += perf * CFG.DEV_PERF_RATE;
+      player.potential = clamp(player.potential + perf * CFG.DEV_POT_RATE * weight, 0, 100);
+    }
+
+    player.potential = clamp(
+      player.potential + (player.drawnPotential - player.potential) * CFG.DEV_POT_REVERSION,
+      0, 100,
+    );
+    setSkill(player, clamp(player.skillExact + delta, 0, 100));
+  }
+}
+
+// The integer skill change a player has made over a timeframe (a DEV_TIMEFRAMES
+// key), for the squad list's "Dev" column. "Last N weeks" reads the rolling
+// skillLog; "season"/"join" read the snapshot marks. Missing data (old saves,
+// players with no history yet) reads as no change.
+export function developmentDelta(player, timeframe) {
+  const now = Math.round(player.skill);
+  if (timeframe === 'season') {
+    return player.seasonStartSkill == null ? 0 : now - Math.round(player.seasonStartSkill);
+  }
+  if (timeframe === 'join') {
+    return player.joinSkill == null ? 0 : now - Math.round(player.joinSkill);
+  }
+  // "Last N weeks": the log holds one skill value per past week (most recent
+  // last). Compare to the value `weeks` entries back, or the oldest we have.
+  const spec = CFG.DEV_TIMEFRAMES.find(t => t.key === timeframe);
+  const log = player.skillLog;
+  if (!spec || !spec.weeks || !log || !log.length) return 0;
+  const idx = log.length - 1 - spec.weeks;
+  const past = idx >= 0 ? log[idx] : log[0];
+  return now - Math.round(past);
 }
 
 // A player's transfer market value: blends current skill with the projected

--- a/src/assets/js/PlayerFactory.js
+++ b/src/assets/js/PlayerFactory.js
@@ -25,6 +25,9 @@ export function makePlayer() {
   const potential = HLP.getBiasedRnd(0, 100, CFG.DRAFT_AVG_POTENTIAL, 1, 0.7);
   const age = randomInt(CFG.PLAYER_AGE_MIN, CFG.PLAYER_AGE_MAX);
   const optimalAge = randomInt(CFG.PLAYER_OPTAGE_MIN, CFG.PLAYER_OPTAGE_MAX);
+  // The calendar week (1..SEASON_WEEKS) the player has his birthday — he ages
+  // one year on that week, so the league's players age staggered, not all at once.
+  const birthWeek = randomInt(1, CFG.SEASON_WEEKS);
 
   // Skill: potential decayed by AGE_FACTOR per year of distance to the optimal age.
   const skill = Math.floor(potential * Math.pow(CFG.AGE_FACTOR, Math.abs(age - optimalAge)));
@@ -51,15 +54,29 @@ export function makePlayer() {
     firstName: randomItem(Names.firstNames),
     lastName: randomItem(Names.lastNames),
     age,
+    birthWeek,
     potential,
+    // The potential the player was drawn with; development drifts `potential`
+    // away from it and reverts gently back toward it, bounding league drift.
+    drawnPotential: potential,
     optimalAge,
     greed,
     skill,
+    // The exact (fractional) skill that continuous weekly development accumulates
+    // into; `skill` is its rounded mirror, read everywhere else.
+    skillExact: skill,
+    // Skill at the start of the current season, snapshot for the UI's season
+    // development delta; reset at every season change.
+    seasonStartSkill: skill,
+    // Skill when the player joined the manager's club (set on ADD_TO_TEAM), and a
+    // rolling weekly skill log — both feed the squad list's skill-change column.
+    joinSkill: skill,
+    skillLog: [],
     positions,
     skills: getSkills(position, skill),
     salary,
-    // Per-season match-rating log; feeds the season average (and later player
-    // development). Reset at every season change.
+    // Per-season match-rating log; feeds the displayed season average note.
+    // Reset at every season change.
     season: { games: 0, ratingSum: 0 },
   };
 }

--- a/src/components/DropdownMenu.vue
+++ b/src/components/DropdownMenu.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="dropdown" :class="{ up }" @click.stop>
+    <div v-if="heading" class="dropdown-heading">{{ heading }}</div>
     <button
       v-for="(option, index) in options"
       :key="index"
@@ -29,6 +30,8 @@ export default {
     // so parents can attach their payload (player, formation, …).
     options: { type: Array, required: true },
     emptyText: { type: String, default: 'No options' },
+    // Optional label shown above the options.
+    heading: { type: String, default: '' },
   },
 
   emits: ['select', 'close'],
@@ -108,6 +111,15 @@ export default {
   border-radius: 8px;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
   cursor: default;
+}
+
+// Optional title above the options.
+.dropdown-heading {
+  padding: 4px 8px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: $col_text_secondary;
+  white-space: nowrap;
 }
 
 .option {

--- a/src/components/PlayerList.vue
+++ b/src/components/PlayerList.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="player-list">
-    <div v-if="title" class="list-headline">{{ title }}</div>
+    <div v-if="title || $slots['header-actions']" class="list-header">
+      <span v-if="title" class="list-headline">{{ title }}</span>
+      <span v-if="$slots['header-actions']" class="header-actions"><slot name="header-actions"/></span>
+    </div>
     <ListRow header>
       <div v-if="numbered" class="rank">#</div>
       <div
@@ -15,6 +18,12 @@
         :class="['metric', 'sortable', { active: sortKey === 'skill' }]"
         @click="sortBy('skill')"
       >Skill<span class="arrow">{{ arrow('skill') }}</span></div>
+      <div
+        v-if="showDevelopment"
+        :class="['metric', 'dev', 'sortable', { active: sortKey === 'development' }]"
+        :title="devColumnTitle"
+        @click="sortBy('development')"
+      >Dev<span class="arrow">{{ arrow('development') }}</span></div>
       <div
         :class="['metric', 'sortable', { active: sortKey === 'age' }]"
         @click="sortBy('age')"
@@ -66,6 +75,9 @@
         />
       </div>
       <div class="metric">{{ player.skill }}</div>
+      <div v-if="showDevelopment" class="metric dev">
+        <span :class="['dev-delta', devClass(player)]">{{ devLabel(player) }}</span>
+      </div>
       <div class="metric">{{ player.age }}</div>
       <div v-if="showSalary" class="metric salary">{{ formatSalary(player.salary) }}</div>
       <div v-if="showValue" class="metric value">{{ formatValue(player) }}</div>
@@ -79,11 +91,12 @@
 
 <script>
 import ListRow from './ListRow.vue';
-import { moneyStr, marketValue } from '../assets/js/Helpers.js';
+import { moneyStr, marketValue, developmentDelta } from '../assets/js/Helpers.js';
+import { DEV_TIMEFRAMES } from '../assets/js/Config.js';
 
 // Default sort direction per column. Position reads ascending (GK → RF),
-// while skill/salary/value read best-first.
-const DEFAULT_DIR = { position: 'asc', name: 'asc', skill: 'desc', age: 'asc', salary: 'desc', value: 'desc', club: 'asc' };
+// while skill/development/salary/value read best-first.
+const DEFAULT_DIR = { position: 'asc', name: 'asc', skill: 'desc', development: 'desc', age: 'asc', salary: 'desc', value: 'desc', club: 'asc' };
 
 export default {
   name: 'PlayerList',
@@ -102,6 +115,10 @@ export default {
     showValue: { type: Boolean, default: false },
     // Selling club column; reads `clubName` off the player entries.
     showClub: { type: Boolean, default: false },
+    // Squad page: skill-change ("Dev") column, measured over `timeframe`.
+    showDevelopment: { type: Boolean, default: false },
+    // A DEV_TIMEFRAMES key the development delta is measured over.
+    timeframe: { type: String, default: 'season' },
     // Ids of players listed on the transfer market (marked with an icon).
     listedIds: { type: Object, default: null },
     // Team page: make rows drag handles + swap targets for the lineup editor.
@@ -128,6 +145,11 @@ export default {
   },
 
   computed: {
+    devColumnTitle() {
+      const label = (DEV_TIMEFRAMES.find(t => t.key === this.timeframe) || {}).label || '';
+      return `Skill change · ${label}`;
+    },
+
     sortedPlayers() {
       const dir = this.sortDir === 'asc' ? 1 : -1;
       return [...this.players].sort((a, b) => {
@@ -153,6 +175,7 @@ export default {
         case 'position': return a.positions.sort - b.positions.sort;
         case 'name': return (a.lastName + a.firstName).localeCompare(b.lastName + b.firstName);
         case 'skill': return a.skill - b.skill;
+        case 'development': return developmentDelta(a, this.timeframe) - developmentDelta(b, this.timeframe);
         case 'age': return a.age - b.age;
         case 'salary': return a.salary - b.salary;
         case 'value': return marketValue(a) - marketValue(b);
@@ -184,6 +207,19 @@ export default {
 
     formatValue(player) {
       return moneyStr(marketValue(player)) + ' €';
+    },
+
+    // Skill change over the selected timeframe, for the "Dev" column.
+    devDelta(player) {
+      return developmentDelta(player, this.timeframe);
+    },
+    devLabel(player) {
+      const d = this.devDelta(player);
+      return d > 0 ? `+${d}` : String(d);
+    },
+    devClass(player) {
+      const d = this.devDelta(player);
+      return d > 0 ? 'up' : d < 0 ? 'down' : 'zero';
     },
   },
 }
@@ -248,6 +284,31 @@ export default {
   width: 42px;
   flex-shrink: 0;
   text-align: center;
+}
+
+// Skill-change column: green when up, red when down, default text at zero.
+.metric.dev {
+  width: 38px;
+}
+
+.dev-delta {
+  font-weight: 600;
+
+  &.up { color: $col_2000; }
+  &.down { color: #d64545; }
+}
+
+// Title row: list headline on the left, optional header controls on the right.
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header-actions {
+  display: inline-flex;
+  align-items: center;
+  padding-right: 8px;
 }
 
 .salary,

--- a/src/store/Club.js
+++ b/src/store/Club.js
@@ -1,5 +1,6 @@
 import { makeClubName } from '@/assets/js/ClubFactory.js';
 import * as CFG from '@/assets/js/Config.js';
+import * as SCHED from '@/assets/js/Schedule.js';
 
 export const clubModule = {
   state: {
@@ -51,10 +52,19 @@ export const clubModule = {
       dispatch('advanceCalendar');
     },
 
-    // The weekly tail shared by advanceWeek and finishMatch: the transfer market
-    // gets its round (fresh AI listings, one buy opportunity per AI club), then
-    // time moves on. After week 52 a new season starts.
-    advanceCalendar({ commit, dispatch, state }) {
+    // The weekly tail shared by advanceWeek and finishMatch. Development runs
+    // every week: on a match week the matchday actions already committed
+    // DEVELOP_WEEK with the real ratings, so here we only develop the
+    // training-only (match-free) weeks; birthdays (aging) are processed every
+    // week. Then the transfer round runs and time moves on (a new season after
+    // week 52).
+    advanceCalendar({ commit, dispatch, state, rootState }) {
+      const matchday = SCHED.matchdayForWeek(state.week);
+      const playedThisWeek = matchday !== null && rootState.league.results[matchday];
+      if (!playedThisWeek) commit('DEVELOP_WEEK', { ratings: {} });
+
+      commit('AGE_BIRTHDAYS', { week: state.week });
+
       dispatch('refreshAiListings');
       dispatch('runAiTransfers');
       if (state.week >= CFG.SEASON_WEEKS) {
@@ -63,22 +73,22 @@ export const clubModule = {
         commit('ADVANCE_WEEK');
       }
       // Re-roll every AI club's sheet now that the transfer round (and any
-      // season-change aging) is done, so next matchday plays the current squads.
+      // retirements) are done, so next matchday plays the current squads.
       dispatch('regenerateAiFormations');
     },
 
-    // Closes the season: every player ages a year (the AI clubs re-pick their
-    // formation, the own club's recommendedFormation getter follows the squad
-    // anyway), the market drops listings of retired players, and the next
-    // season starts with a fresh schedule and a cleared table.
+    // Closes the season: players past the age limit retire (kept until the
+    // rollover so they finish the season), the market drops their listings, then
+    // season logs reset and a fresh schedule/cleared table starts. Aging itself
+    // is staggered across birthdays during the season.
     startNewSeason({ commit, rootState }) {
-      commit('AGE_TEAM');
-      commit('AGE_CLUBS');
+      commit('RETIRE_AGED');
       const activeIds = new Set([
         ...rootState.team.players.map(p => p.id),
         ...rootState.league.clubs.flatMap(c => c.players.map(p => p.id)),
       ]);
       commit('PRUNE_LISTINGS', activeIds);
+      commit('RESET_SEASON_STATS');
       commit('START_NEW_SEASON');
       commit('MAKE_SCHEDULE');
     },

--- a/src/store/League.js
+++ b/src/store/League.js
@@ -193,17 +193,44 @@ export const leagueModule = {
       for (const club of state.clubs) HLP.applySeasonRatings(club.players, ratings);
     },
 
-    // Season change: every AI club's players age a year, players past the age
-    // limit retire, and the club re-picks its strongest formation. Careers may
-    // shrink a squad below MIN_SQUAD_SIZE — the minimum only blocks sales.
-    AGE_CLUBS(state) {
+    // One week of development for every AI club squad (full squad, not just the
+    // XI). The team module defines the same mutation for the own squad, so a
+    // single commit('DEVELOP_WEEK') develops the whole league identically.
+    DEVELOP_WEEK(state, { ratings }) {
+      for (const club of state.clubs) HLP.developPlayers(club.players, ratings);
+    },
+
+    // Birthdays for the given week: AI players born this week age a year. Aging
+    // is staggered, but a player who passes the age limit keeps playing until the
+    // season ends (retirement happens at the rollover, see RETIRE_AGED).
+    AGE_BIRTHDAYS(state, { week }) {
       for (const club of state.clubs) {
         for (const player of club.players) {
-          HLP.agePlayer(player);
-          player.season = { games: 0, ratingSum: 0 };
+          if ((player.birthWeek ?? 1) === week) HLP.agePlayer(player);
         }
+      }
+    },
+
+    // Season change: AI players past the age limit retire and the affected clubs
+    // re-pick their formation. Done once at the rollover so a player who turns 35
+    // mid-season still finishes the season.
+    RETIRE_AGED(state) {
+      for (const club of state.clubs) {
+        const before = club.players.length;
         club.players = club.players.filter(p => p.age <= CFG.PLAYER_AGE_MAX);
-        club.formation = HLP.getRecommendedFormation(club.players);
+        if (club.players.length !== before) club.formation = HLP.getRecommendedFormation(club.players);
+      }
+    },
+
+    // Season change: reset every AI player's season note log and snapshot the
+    // skill they start the new season with (for the UI development delta). Aging
+    // is staggered on birthdays; retirement is RETIRE_AGED, also at the rollover.
+    RESET_SEASON_STATS(state) {
+      for (const club of state.clubs) {
+        for (const player of club.players) {
+          player.season = { games: 0, ratingSum: 0 };
+          player.seasonStartSkill = player.skill;
+        }
       }
     },
 
@@ -262,7 +289,7 @@ export const leagueModule = {
     // resulting ratings are folded into every player's season log.
     playMatchday({ commit, state, getters, rootState }) {
       const matchday = SCHED.matchdayForWeek(rootState.club.week);
-      if (matchday === null || !state.fixtures[matchday] || state.results[matchday]) return;
+      if (matchday === null || !state.fixtures[matchday] || state.results[matchday]) return {};
 
       const ratings = {};
       const results = state.fixtures[matchday].map(({ home, away }) => {
@@ -272,6 +299,8 @@ export const leagueModule = {
       });
       commit('RECORD_MATCHDAY', { matchday, results });
       commit('APPLY_RATINGS', { ratings });
+      commit('DEVELOP_WEEK', { ratings });
+      return ratings;
     },
 
     // Records the matchday around the match the manager just watched: the
@@ -279,7 +308,7 @@ export const leagueModule = {
     // instant-simulated. Same guard as playMatchday so a replay is ignored.
     playPlayerMatchday({ commit, state, getters, rootState }, live) {
       const matchday = SCHED.matchdayForWeek(rootState.club.week);
-      if (matchday === null || !state.fixtures[matchday] || state.results[matchday]) return;
+      if (matchday === null || !state.fixtures[matchday] || state.results[matchday]) return {};
 
       const ratings = {};
       const results = state.fixtures[matchday].map(({ home, away }) => {
@@ -293,6 +322,8 @@ export const leagueModule = {
       });
       commit('RECORD_MATCHDAY', { matchday, results });
       commit('APPLY_RATINGS', { ratings });
+      commit('DEVELOP_WEEK', { ratings });
+      return ratings;
     },
   },
 }

--- a/src/store/Team.js
+++ b/src/store/Team.js
@@ -12,6 +12,8 @@ export const teamModule = {
     formations: {},
     // Name of the current default formation — the one played in matches.
     activeFormation: null,
+    // Squad list's skill-change column timeframe (a DEV_TIMEFRAMES key).
+    devTimeframe: CFG.DEV_DEFAULT_TIMEFRAME,
   },
 
   getters: {
@@ -37,6 +39,10 @@ export const teamModule = {
 
   mutations: {
     ADD_TO_TEAM(state, player) {
+      // Mark where the player's tenure at this club starts, for the "since
+      // joining" change and a fresh weekly log (pre-join weeks weren't tracked).
+      player.joinSkill = player.skill;
+      player.skillLog = [];
       state.players.push(player);
       state.positionCount = getTeamPositionCount(state.players);
       state.players.sort((a, b) => a.positions.sort - b.positions.sort || b.skill - a.skill);
@@ -58,16 +64,53 @@ export const teamModule = {
       HLP.applySeasonRatings(state.players, ratings);
     },
 
-    // Season change: every player ages a year and their season log resets;
-    // players past the age limit end their career and leave the squad.
-    AGE_TEAM(state) {
+    // One week of development for the own squad (full squad; bench/reserve at a
+    // reduced training weight). League defines the same mutation for AI clubs.
+    // After developing, each player's weekly skill is logged (capped) so the
+    // squad list can show the change over the last N weeks.
+    DEVELOP_WEEK(state, { ratings }) {
+      HLP.developPlayers(state.players, ratings);
       for (const player of state.players) {
-        HLP.agePlayer(player);
-        player.season = { games: 0, ratingSum: 0 };
+        if (!player.skillLog) player.skillLog = [];
+        player.skillLog.push(player.skill);
+        if (player.skillLog.length > CFG.DEV_HISTORY_WEEKS) player.skillLog.shift();
       }
+    },
+
+    // Persists the squad list's skill-change timeframe (a DEV_TIMEFRAMES key).
+    SET_DEV_TIMEFRAME(state, timeframe) {
+      state.devTimeframe = timeframe;
+    },
+
+    // Birthdays for the given week: own players born this week age a year. Aging
+    // is staggered, but a player who passes the age limit keeps playing until the
+    // season ends (retirement happens at the rollover, see RETIRE_AGED).
+    AGE_BIRTHDAYS(state, { week }) {
+      for (const player of state.players) {
+        if ((player.birthWeek ?? 1) === week) HLP.agePlayer(player);
+      }
+    },
+
+    // Season change: players past the age limit end their career and leave the
+    // squad, with the sheets reconciled. Done once at the rollover so a player
+    // who turns 35 mid-season still finishes the season.
+    RETIRE_AGED(state) {
+      const before = state.players.length;
       state.players = state.players.filter(p => p.age <= CFG.PLAYER_AGE_MAX);
-      state.positionCount = getTeamPositionCount(state.players);
-      reconcileFormations(state);
+      if (state.players.length !== before) {
+        state.positionCount = getTeamPositionCount(state.players);
+        reconcileFormations(state);
+      }
+    },
+
+    // Season change: reset the own squad's season note logs and snapshot the
+    // skill each player starts the season with (for the UI development delta).
+    // Aging is staggered on birthdays; retirement is RETIRE_AGED, also here.
+    RESET_SEASON_STATS(state) {
+      for (const player of state.players) {
+        player.season = { games: 0, ratingSum: 0 };
+        player.seasonStartSkill = player.skill;
+      }
     },
 
     // Fills every formation with a saved team sheet from the current squad and

--- a/src/views/Players.vue
+++ b/src/views/Players.vue
@@ -7,8 +7,31 @@
         :listed-ids="listedIds"
         show-salary
         show-value
+        show-development
+        :timeframe="devTimeframe"
         action-width="24px"
       >
+        <template #header-actions>
+          <div class="timeframe-menu" :class="{ open }">
+            <button
+              type="button"
+              class="dots-btn"
+              aria-label="Skill-change timeframe"
+              title="Skill-change timeframe"
+              @click="open = !open"
+            >
+              <img src="../assets/img/icons/dots-white.svg" alt=""/>
+            </button>
+            <DropdownMenu
+              v-if="open"
+              heading="Player development"
+              :options="timeframeOptions"
+              @select="onSelect"
+              @close="open = false"
+            />
+          </div>
+        </template>
+
         <template #actions="{ player }">
           <PlayerRowMenu :player="player"/>
         </template>
@@ -20,6 +43,8 @@
 <script>
 import PlayerList from '../components/PlayerList.vue';
 import PlayerRowMenu from '../components/PlayerRowMenu.vue';
+import DropdownMenu from '../components/DropdownMenu.vue';
+import { DEV_TIMEFRAMES } from '../assets/js/Config.js';
 
 export default {
   name: 'Players',
@@ -27,11 +52,30 @@ export default {
   components: {
     PlayerList,
     PlayerRowMenu,
+    DropdownMenu,
   },
+
+  data: () => ({ open: false }),
 
   computed: {
     players() { return this.$store.state.team.players },
     listedIds() { return this.$store.getters.listedPlayerIds },
+    devTimeframe() { return this.$store.state.team.devTimeframe },
+
+    timeframeOptions() {
+      return DEV_TIMEFRAMES.map(t => ({
+        label: t.label,
+        action: t.key,
+        selected: t.key === this.devTimeframe,
+      }));
+    },
+  },
+
+  methods: {
+    onSelect(option) {
+      this.$store.commit('SET_DEV_TIMEFRAME', option.action);
+      this.open = false;
+    },
   },
 }
 </script>
@@ -43,11 +87,50 @@ export default {
   padding: 12px;
 }
 
-// Sized to the columns (position, name, skill, age, salary, value, menu).
+// Sized to the columns (position, name, skill, dev, age, salary, value, menu).
 .list-card {
-  max-width: 640px;
+  max-width: 660px;
   margin: 0 auto;
   overflow: visible;
+}
+
+// Anchor for the timeframe flyout, opened right-aligned under the dots button.
+.timeframe-menu {
+  position: relative;
+}
+
+.timeframe-menu.open {
+  z-index: $z_overlay;
+}
+
+.timeframe-menu :deep(.dropdown) {
+  left: auto;
+  right: 0;
+  width: auto;
+}
+
+.dots-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 0.1s ease;
+}
+
+.dots-btn:hover {
+  background-color: $col_module_border;
+}
+
+.dots-btn img {
+  display: block;
+  width: 16px;
+  height: 16px;
 }
 
 </style>

--- a/tests/development.test.js
+++ b/tests/development.test.js
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { developPlayers, projectedSkill, developmentDelta } from '../src/assets/js/Helpers.js';
+import { makeClub } from '../src/assets/js/ClubFactory.js';
+import { simulateInstant } from '../src/assets/js/MatchSim.js';
+import * as CFG from '../src/assets/js/Config.js';
+
+let nextId = 1;
+// A player at a chosen age/potential. By default skill sits exactly on its age
+// curve (target), so convergence is zero and the performance push is isolated.
+function devPlayer(over = {}) {
+  const age = over.age ?? 28;
+  const optimalAge = over.optimalAge ?? 28;
+  const potential = over.potential ?? 60;
+  const onCurve = Math.floor(potential * Math.pow(CFG.AGE_FACTOR, Math.abs(age - optimalAge)));
+  const skill = over.skill ?? onCurve;
+  return {
+    id: over.id ?? nextId++,
+    age, optimalAge, potential, drawnPotential: over.drawnPotential ?? potential,
+    skill, skillExact: skill,
+    positions: { position: over.position ?? 'ST' },
+    skills: over.skills ?? { goalkeeping: 0, defense: 0, progression: Math.round(skill * 0.3), shot: Math.round(skill * 0.7) },
+  };
+}
+
+// Runs `weeks` of development; `rating` (if given) marks the player as having
+// played each week, otherwise he's a bench/training week.
+function runWeeks(player, weeks, rating) {
+  for (let i = 0; i < weeks; i++) developPlayers([player], rating == null ? {} : { [player.id]: rating });
+  return player;
+}
+
+describe('developPlayers', () => {
+  it('raises skill for a striker rating above his role baseline', () => {
+    const p = devPlayer({ position: 'ST' });
+    const start = p.skill;
+    runWeeks(p, 34, CFG.DEV_BASELINE.ATT + 1.5);
+    expect(p.skill).toBeGreaterThan(start);
+  });
+
+  it('lowers skill for a striker rating below his role baseline', () => {
+    const p = devPlayer({ position: 'ST' });
+    const start = p.skill;
+    runWeeks(p, 34, CFG.DEV_BASELINE.ATT - 1.5);
+    expect(p.skill).toBeLessThan(start);
+  });
+
+  it('leaves an on-curve player who rates exactly his baseline unchanged', () => {
+    const p = devPlayer({ position: 'ST' });
+    const start = p.skill;
+    runWeeks(p, 34, CFG.DEV_BASELINE.ATT);
+    expect(p.skill).toBe(start);
+    expect(p.potential).toBeCloseTo(p.drawnPotential, 5);
+  });
+
+  it('develops a benched player less than one who plays', () => {
+    // Both start below their curve target, so convergence pulls them up.
+    const played = devPlayer({ age: 22, optimalAge: 28, potential: 70, skill: 40, position: 'ST' });
+    const benched = devPlayer({ age: 22, optimalAge: 28, potential: 70, skill: 40, position: 'ST' });
+    runWeeks(played, 10, CFG.DEV_BASELINE.ATT);  // plays, rating = neutral (pure convergence at full weight)
+    runWeeks(benched, 10);                        // never played (training weight)
+    expect(played.skill).toBeGreaterThan(benched.skill);
+    expect(benched.skill).toBeGreaterThan(40);    // but still developed
+  });
+
+  it('grows a young player toward his potential and declines an old one', () => {
+    const young = devPlayer({ age: 20, optimalAge: 29, potential: 75, skill: 45 });
+    const old = devPlayer({ age: 33, optimalAge: 28, potential: 75, skill: 60 });
+    runWeeks(young, 40);
+    runWeeks(old, 40);
+    expect(young.skill).toBeGreaterThan(45);
+    expect(young.skill).toBeLessThanOrEqual(projectedSkill(young, 0) + 1);
+    expect(old.skill).toBeLessThan(60);
+  });
+
+  it('drifts potential up on strong play and reverts it toward the drawn value', () => {
+    const p = devPlayer({ position: 'ST' });
+    runWeeks(p, 34, CFG.DEV_BASELINE.ATT + 2);   // a strong season
+    expect(p.potential).toBeGreaterThan(p.drawnPotential);
+    const peak = p.potential;
+    runWeeks(p, 60, CFG.DEV_BASELINE.ATT);        // neutral play -> reversion pulls back
+    expect(p.potential).toBeLessThan(peak);
+    expect(p.potential).toBeGreaterThanOrEqual(p.drawnPotential - 0.001);
+  });
+
+  it('keeps skill and potential within [0, 100]', () => {
+    const p = devPlayer({ age: 28, optimalAge: 28, potential: 99, skill: 99, position: 'ST' });
+    runWeeks(p, 200, 10);  // way over baseline, capped internally
+    expect(p.skill).toBeLessThanOrEqual(100);
+    expect(p.potential).toBeLessThanOrEqual(100);
+    expect(p.skill).toBeGreaterThanOrEqual(0);
+  });
+
+  it('is a safe no-op shape on an old save missing dev fields', () => {
+    const legacy = {
+      id: nextId++, age: 25, optimalAge: 28, potential: 55, skill: 50,
+      positions: { position: 'CB' },
+      skills: { goalkeeping: 0, defense: 40, progression: 10, shot: 0 },
+      // no skillExact, no drawnPotential
+    };
+    expect(() => developPlayers([legacy], { [legacy.id]: 7 })).not.toThrow();
+    expect(legacy.skillExact).not.toBeUndefined();
+    expect(legacy.drawnPotential).toBe(55);
+    expect(Number.isFinite(legacy.skill)).toBe(true);
+  });
+});
+
+describe('developmentDelta', () => {
+  it('measures change vs the season-start and join marks', () => {
+    const p = { skill: 56, seasonStartSkill: 50, joinSkill: 48, skillLog: [] };
+    expect(developmentDelta(p, 'season')).toBe(6);
+    expect(developmentDelta(p, 'join')).toBe(8);
+  });
+
+  it('measures change over the last N weeks from the rolling log', () => {
+    // Log holds one skill per past week, most recent last (= current skill).
+    const p = { skill: 55, skillLog: [50, 51, 52, 53, 54, 55] };
+    expect(developmentDelta(p, 'w5')).toBe(5);   // 55 now vs 50 five weeks ago
+    expect(developmentDelta(p, 'w20')).toBe(5);  // fewer than 20 entries -> oldest (50)
+  });
+
+  it('reads as zero change with no signal or on old saves', () => {
+    expect(developmentDelta({ skill: 50, skillLog: [] }, 'w5')).toBe(0);
+    expect(developmentDelta({ skill: 50 }, 'season')).toBe(0); // no seasonStartSkill
+    expect(developmentDelta({ skill: 50 }, 'join')).toBe(0);   // no joinSkill
+    expect(developmentDelta({ skill: 50, seasonStartSkill: 50, skillLog: [] }, 'season')).toBe(0);
+  });
+});
+
+describe('league development stability', () => {
+  // Isolates the development balance: many seasons of real matches + weekly
+  // development with a FIXED population (no aging/retirement, which the game has
+  // no youth intake to replace). The per-role baselines should keep the league
+  // mean skill from inflating or collapsing over time.
+  it('keeps the league skill distribution stable over many seasons', () => {
+    const flatten = lineup => Object.entries(lineup).flatMap(([pos, players]) =>
+      players.filter(Boolean).map(player => ({ player, position: pos.toUpperCase() })));
+    const clubs = Array.from({ length: 18 }, (_, i) => makeClub(i, `C${i}`));
+    const allSkills = () => clubs.flatMap(c => c.players.map(p => p.skill));
+    const mean = a => a.reduce((s, x) => s + x, 0) / a.length;
+    const p95 = a => [...a].sort((x, y) => x - y)[Math.floor(a.length * 0.95)];
+
+    const startMean = mean(allSkills());
+    const startP95 = p95(allSkills());
+
+    const SEASONS = 20;
+    for (let s = 0; s < SEASONS; s++) {
+      // ~34 match weeks: pair clubs, rate them, develop with the ratings.
+      for (let day = 0; day < 34; day++) {
+        const order = clubs.map((_, i) => i).sort(() => Math.random() - 0.5);
+        const ratings = {};
+        for (let i = 0; i + 1 < order.length; i += 2) {
+          const home = { xi: flatten(clubs[order[i]].formation.players), strength: clubs[order[i]].formation.skillSum };
+          const away = { xi: flatten(clubs[order[i + 1]].formation.players), strength: clubs[order[i + 1]].formation.skillSum };
+          Object.assign(ratings, simulateInstant(home, away).ratings);
+        }
+        for (const c of clubs) developPlayers(c.players, ratings);
+      }
+      // ~18 training weeks.
+      for (let w = 0; w < 18; w++) for (const c of clubs) developPlayers(c.players, {});
+    }
+
+    const endMean = mean(allSkills());
+    const endP95 = p95(allSkills());
+    // No runaway drift in either direction over 20 seasons.
+    expect(Math.abs(endMean - startMean)).toBeLessThan(4);
+    expect(Math.abs(endP95 - startP95)).toBeLessThan(6);
+  }, 30000);
+});

--- a/tests/season.test.js
+++ b/tests/season.test.js
@@ -129,55 +129,50 @@ describe('advanceWeek', () => {
   });
 });
 
-describe('season change', () => {
-  it('ages every player by one year along the development curve', () => {
+describe('staggered aging & retirement', () => {
+  it('ages a player only on his birthday week, leaving others untouched', () => {
     const store = makeStore();
-    const own = stubPlayer(100, 25);
-    const ai = stubPlayer(101, 30);
-    store.state.team.players = [own];
+    const own = stubPlayer(100, 25); own.birthWeek = 3;
+    const notYet = stubPlayer(101, 25); notYet.birthWeek = 4;
+    const ai = stubPlayer(102, 30); ai.birthWeek = 3;
+    store.state.team.players = [own, notYet];
     store.state.league.clubs[0].players = [ai];
-    store.state.club.week = CFG.SEASON_WEEKS;
+    store.state.club.week = 3;
 
-    const expectedOwnSkill = HLP.projectedSkill(own, 1);
-    const expectedAiSkill = HLP.projectedSkill(ai, 1);
-    const expectedDefense = Math.round(own.skills.defense * expectedOwnSkill / own.skill);
-    const expectedProgression = Math.round(own.skills.progression * expectedOwnSkill / own.skill);
-
-    store.dispatch('advanceWeek');
+    store.dispatch('advanceWeek'); // completes week 3
 
     expect(own.age).toBe(26);
-    expect(own.skill).toBe(expectedOwnSkill);
-    expect(own.skills.defense).toBe(expectedDefense);
-    expect(own.skills.progression).toBe(expectedProgression);
     expect(ai.age).toBe(31);
-    expect(ai.skill).toBe(expectedAiSkill);
+    expect(notYet.age).toBe(25); // his birthday is week 4
   });
 
-  it('retires players turning 35 from squad, formation and listings', () => {
+  it('keeps an over-age player through the season, then retires him at the rollover', () => {
     const store = makeStore();
-    const retiringOwn = stubPlayer(100, CFG.PLAYER_AGE_MAX);
-    const stayingOwn = stubPlayer(101, 28);
+    const retiringOwn = stubPlayer(100, CFG.PLAYER_AGE_MAX); retiringOwn.birthWeek = 5;
+    const stayingOwn = stubPlayer(101, 28); stayingOwn.birthWeek = 5;
     store.state.team.players = [retiringOwn, stayingOwn];
     const club = store.state.league.clubs[0];
-    const retiringAi = stubPlayer(102, CFG.PLAYER_AGE_MAX);
-    const stayingAi = stubPlayer(103, 22);
+    const retiringAi = stubPlayer(102, CFG.PLAYER_AGE_MAX); retiringAi.birthWeek = 5;
+    const stayingAi = stubPlayer(103, 22); stayingAi.birthWeek = 5;
     club.players = [retiringAi, stayingAi];
     store.state.transferMarket.listings = [
       { playerId: retiringOwn.id, sellerClubId: null, price: HLP.marketValue(retiringOwn) },
     ];
-    store.state.club.week = CFG.SEASON_WEEKS;
 
+    // Birthday in week 5: he turns 35 but plays on — no mid-season retirement.
+    store.state.club.week = 5;
     store.dispatch('advanceWeek');
+    expect(retiringOwn.age).toBe(CFG.PLAYER_AGE_MAX + 1);
+    expect(store.state.team.players.map(p => p.id)).toContain(100);
+    expect(club.players.map(p => p.id)).toContain(102);
 
+    // Season rollover: now the over-age players retire and their listings drop.
+    store.state.club.week = CFG.SEASON_WEEKS;
+    store.dispatch('advanceWeek');
     expect(store.state.team.players.map(p => p.id)).toEqual([stayingOwn.id]);
     expect(club.players.map(p => p.id)).toEqual([stayingAi.id]);
     expect(store.state.transferMarket.listings
       .some(l => l.playerId === retiringOwn.id)).toBe(false);
-
-    // The AI club re-picked its formation from the remaining squad.
-    const lineupIds = Object.values(club.formation.players).flat().map(p => p.id);
-    expect(lineupIds).toEqual([stayingAi.id]);
-    expect(store.getters.recommendedFormation.skillSum).toBe(stayingOwn.skill);
   });
 });
 
@@ -231,6 +226,29 @@ describe('season ratings', () => {
 
     expect(own.season).toEqual({ games: 0, ratingSum: 0 });
     expect(ai.season).toEqual({ games: 0, ratingSum: 0 });
+  });
+});
+
+describe('squad skill-change tracking', () => {
+  it('captures joinSkill and a fresh log when a player joins the club', () => {
+    const store = makeStore();
+    const p = stubPlayer(200, 24);
+    p.joinSkill = 5; p.skillLog = [1, 2, 3]; // stale values, should be reset on join
+
+    store.dispatch('addPlayerToTeam', p);
+
+    expect(p.joinSkill).toBe(p.skill);
+    expect(p.skillLog).toEqual([]);
+  });
+
+  it('logs one weekly skill per DEVELOP_WEEK and caps the history', () => {
+    const store = makeStore();
+    const p = stubPlayer(201, 24);
+    store.state.team.players = [p];
+
+    for (let i = 0; i < CFG.DEV_HISTORY_WEEKS + 5; i++) store.commit('DEVELOP_WEEK', { ratings: {} });
+
+    expect(p.skillLog.length).toBe(CFG.DEV_HISTORY_WEEKS);
   });
 });
 


### PR DESCRIPTION
## Summary
Players now develop **week by week from match performance** instead of a fixed age curve recomputed once per season.

- Each week, every squad player's skill chases its natural age-curve value (training/aging — bench/reserve at a reduced weight); a match rating above the player's **empirical per-role baseline** pushes skill above the curve and drifts **potential** up (below → down). Potential reverts toward its drawn value, so the league stays balanced over many seasons.
- Skill accumulates in a fractional `skillExact` that rounds into the integer `skill`, so tiny weekly steps don't vanish and no other display site changed.
- **Staggered aging**: each player has a `birthWeek` and ages on it; **retirement happens at the season rollover** so a player who turns 35 mid-season finishes the season.
- Applies to the own squad **and** all AI clubs (the non-namespaced `DEVELOP_WEEK`/`AGE_BIRTHDAYS` mutations cover both); persists in the JSON save.

## Squad list "Dev" column
A skill-change column (`+X` green / `-X` red / `0` white), sortable, with a 3-dot flyout (heading **"Player development"**) to pick the timeframe: last 5/10/20 weeks, this season, or since joining the club.

## Verification
- `npm test` — **106 passing**, incl. `developPlayers` units (over/under/neutral/bench/young/vet/clamps/potential drift+reversion/old-save), staggered aging + season-end retirement, a **20-season league-stability sim** (mean/p95 skill bounded), `developmentDelta`, and `skillLog`/`joinSkill` tracking.
- Clean production build.
- Not browser-verified: reaching the squad view needs the PHP backend + a played-through squad (dev values are 0 until weeks pass); logic is unit-tested and SFCs compile.

## Follow-up (out of scope)
The league has no youth intake, so retirements shrink squads over many seasons — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)