### PR TITLE
Scale player development by age (youth learn more)

### DIFF
--- a/src/assets/js/Config.js
+++ b/src/assets/js/Config.js
@@ -30,6 +30,10 @@ export const DEV_PERF_CAP = 2.0;         // clamp rating-baseline to +/- this
 export const DEV_TRAIN_WEIGHT = 0.3;     // convergence weight for bench/reserve (no minutes)
 export const DEV_POT_RATE = 0.045;       // potential drift per (rating point over baseline) on a match week
 export const DEV_POT_REVERSION = 0.012;  // weekly pull of potential back toward its drawn value
+// Younger players learn more from playing: the performance push and potential
+// drift are scaled by 1 + DEV_YOUTH_BONUS * max(0, (optimalAge - age) / 12), so a
+// teenager gains up to ~+50-60% per good game, a peak/declining player gets none.
+export const DEV_YOUTH_BONUS = 0.5;
 
 // Skill-change column in the squad list: the timeframe the change is measured
 // over, chosen from the list header's flyout. "Last N weeks" reads a rolling

--- a/src/assets/js/Helpers.js
+++ b/src/assets/js/Helpers.js
@@ -101,8 +101,11 @@ export function developPlayers(players, ratings = {}) {
       const role = CFG.POSITION_ROLE[player.positions.position] || 'MID';
       const baseline = CFG.DEV_BASELINE[role] ?? CFG.MATCH_RATING_BASE;
       const perf = clamp(rating - baseline, -CFG.DEV_PERF_CAP, CFG.DEV_PERF_CAP);
-      delta += perf * CFG.DEV_PERF_RATE;
-      player.potential = clamp(player.potential + perf * CFG.DEV_POT_RATE * weight, 0, 100);
+      // Youth learn more from playing: full bonus for teenagers, none at/after peak.
+      const optimalAge = player.optimalAge ?? player.age;
+      const youthFactor = 1 + CFG.DEV_YOUTH_BONUS * Math.max(0, (optimalAge - player.age) / 12);
+      delta += perf * CFG.DEV_PERF_RATE * youthFactor;
+      player.potential = clamp(player.potential + perf * CFG.DEV_POT_RATE * youthFactor, 0, 100);
     }
 
     player.potential = clamp(

--- a/tests/development.test.js
+++ b/tests/development.test.js
@@ -72,6 +72,19 @@ describe('developPlayers', () => {
     expect(old.skill).toBeLessThan(60);
   });
 
+  it('develops a young player faster than an older one from the same performance', () => {
+    // Both start on their own age curve; only their age (vs optimalAge) differs.
+    const young = devPlayer({ age: 20, optimalAge: 30, potential: 72, position: 'ST' });
+    const old = devPlayer({ age: 30, optimalAge: 30, potential: 72, position: 'ST' });
+    const youngStart = young.skill, oldStart = old.skill;
+    const rating = CFG.DEV_BASELINE.ATT + 1.5;
+    runWeeks(young, 30, rating);
+    runWeeks(old, 30, rating);
+    expect(young.skill - youngStart).toBeGreaterThan(old.skill - oldStart);
+    // The youth bonus also lifts the ceiling more.
+    expect(young.potential - 72).toBeGreaterThan(old.potential - 72);
+  });
+
   it('drifts potential up on strong play and reverts it toward the drawn value', () => {
     const p = devPlayer({ position: 'ST' });
     runWeeks(p, 34, CFG.DEV_BASELINE.ATT + 2);   // a strong season


### PR DESCRIPTION
## Summary
Makes younger players develop faster from match performance. In `developPlayers` the performance push **and** potential drift are scaled by:

```
youthFactor = 1 + DEV_YOUTH_BONUS * max(0, (optimalAge - age) / 12)   // DEV_YOUTH_BONUS = 0.5
```

- Teenager: ~`+50–60%` per good game · early/mid-20s: smaller · at/after peak: `1.0×` (no bonus, no penalty — decline still comes from the age curve).
- Linear in the distance below optimal age; natural maturation/convergence is unchanged.

## Verification
- `npm test` — passing, incl. a new test that a young striker out-develops an identical older one (skill + potential) from the same rating, and the 20-season league-stability sim still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)