### PR TITLE
Round team total skill in the UI

### DIFF
--- a/src/components/Matchday.vue
+++ b/src/components/Matchday.vue
@@ -30,7 +30,7 @@
           <span class="rank">{{ match.home.rank }}.</span>
           <ClubCrest :crest="crestFor(match.home.id)" :id="'md-' + match.home.id" :size="18"/>
           <span class="name">{{ match.home.name }}</span>
-          <span class="skill">{{ match.home.skill }}</span>
+          <span class="skill">{{ Math.round(match.home.skill) }}</span>
         </div>
         <span class="score" v-if="match.result">{{ match.result.homeGoals }}:{{ match.result.awayGoals }}</span>
         <span class="score dash" v-else></span>
@@ -38,7 +38,7 @@
           <span class="rank">{{ match.away.rank }}.</span>
           <ClubCrest :crest="crestFor(match.away.id)" :id="'md-' + match.away.id" :size="18"/>
           <span class="name">{{ match.away.name }}</span>
-          <span class="skill">{{ match.away.skill }}</span>
+          <span class="skill">{{ Math.round(match.away.skill) }}</span>
         </div>
       </div>
     </div>

--- a/src/components/SquadPreview.vue
+++ b/src/components/SquadPreview.vue
@@ -4,7 +4,7 @@
       <div class="select-wrapper" @click="formationsOpen = !formationsOpen">
         <span class="selectFormation">
           <span class="formation-name">{{ selectedFormation ? selectedFormation.name : 'Overview' }}</span>
-          <span v-if="selectedFormation" class="formation-skill"> · Total skill: {{ selectedFormation.skillSum }}</span>
+          <span v-if="selectedFormation" class="formation-skill"> · Total skill: {{ Math.round(selectedFormation.skillSum) }}</span>
         </span>
         <DropdownMenu
           v-if="formationsOpen"

--- a/src/views/ClubLineup.vue
+++ b/src/views/ClubLineup.vue
@@ -4,7 +4,7 @@
       <div class="club-header">
         <ClubCrest :crest="club.crest" :id="'club-' + club.id" :size="52"/>
         <h2 class="club-name">{{ club.name }}</h2>
-        <div class="formation-name">{{ club.formation.name }} · {{ club.formation.skillSum }}</div>
+        <div class="formation-name">{{ club.formation.name }} · {{ Math.round(club.formation.skillSum) }}</div>
       </div>
 
       <div class="field-wrapper">

--- a/src/views/Table.vue
+++ b/src/views/Table.vue
@@ -26,7 +26,7 @@
         <div class="metric">{{ entry.played }}</div>
         <div class="metric">{{ entry.goalsFor }}:{{ entry.goalsAgainst }}</div>
         <div class="metric">{{ entry.points }}</div>
-        <div class="metric">{{ entry.skill }}</div>
+        <div class="metric">{{ Math.round(entry.skill) }}</div>
       </ListRow>
     </div>
 


### PR DESCRIPTION
## Summary
The team total skill (formation `skillSum`) is a float because fitness scales each player's contribution, so the Standings, matchday pairings, squad-preview header and AI-lineup header displayed long decimals (e.g. `539.35455300…`).

Rounded at the four **display** sites only — the underlying `skillSum` stays precise for the strength/share math:
- `Table.vue` (Standings "Skill")
- `Matchday.vue` (both teams in the pairings)
- `SquadPreview.vue` ("Total skill" header)
- `ClubLineup.vue` (AI club lineup header)

## Verification
Production build clean; full suite (159) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)