### PR TITLE
Tune fitness recovery and add randomized per-minute match drain

### DIFF
--- a/src/assets/js/Config.js
+++ b/src/assets/js/Config.js
@@ -65,12 +65,29 @@ export const STAMINA_PRIME_AGE = 24;     // no age penalty up to this age
 export const STAMINA_AGE_PENALTY = 1.2;  // ceiling points lost per year past the prime age
 // Every player starts each season at full fitness (STAMINA_MAX) and holds it
 // through the match-free pre-season. A full match then drains FITNESS_MATCH_DRAIN
-// and each week he recovers FITNESS_REGEN_RATE of the gap back up toward his
-// ceiling. So once matches begin a weekly starter settles at
-// stamina - FITNESS_MATCH_DRAIN: young/strong players sit in the yellow band
-// (sustainable), older/weaker ones sink into the red and must be rested.
-export const FITNESS_MATCH_DRAIN = 30;   // fitness a full match costs a starter
-export const FITNESS_REGEN_RATE = 0.5;   // fraction of the gap to the ceiling recovered each week
+// and each week he recovers a fraction of the gap back up toward his ceiling.
+// That fraction scales with conditioning (see fitnessRegenRate): the best-
+// conditioned third (stamina >= FITNESS_REGEN_FULL_STAMINA) recover the whole gap
+// — so they fully bounce back from a match each week — while it tapers down to
+// FITNESS_REGEN_MIN for the least-conditioned, who sink into the red and must be
+// rested. So once matches begin a weekly starter settles between his ceiling
+// (top third) and roughly stamina - FITNESS_MATCH_DRAIN (the weakest).
+export const FITNESS_MATCH_DRAIN = 30;       // nominal fitness a full (90') match costs at average intensity
+// Match drain is accumulated minute by minute in the engine: each on-pitch player
+// loses FITNESS_DRAIN_PER_MINUTE, scaled by a per-player per-match intensity
+// (±FITNESS_DRAIN_INTENSITY_SPREAD) plus fine per-minute noise. So totals vary per
+// player (some matches take more out of you), scale with minutes actually played
+// (a sub drains less), and randomly leave even a fit player short some weeks.
+export const FITNESS_DRAIN_PER_MINUTE = FITNESS_MATCH_DRAIN / 90;
+export const FITNESS_DRAIN_INTENSITY_SPREAD = 0.35; // ±35% per-player per-match intensity
+export const FITNESS_DRAIN_MINUTE_JITTER = 0.5;     // ±50% fine per-minute noise (averages out)
+// Weekly recovery is capped at this, so a heavy-drain match isn't fully erased in
+// one week even for a top-conditioned player — that's what lets random heavy
+// matches push anyone toward needing a rest.
+export const FITNESS_RECOVER_MAX = 35;
+export const FITNESS_REGEN_MIN = 0.5;        // weekly recovery fraction for the least-conditioned
+export const FITNESS_REGEN_MIN_STAMINA = 64; // at/below this stamina, recovery is FITNESS_REGEN_MIN
+export const FITNESS_REGEN_FULL_STAMINA = 88;// at/above this stamina (~top third) recovery is full (1.0)
 // Performance malus: at/above FITNESS_PERF_FULL a player is at full strength; it
 // scales his effective skill down linearly to FITNESS_PERF_MIN at zero fitness.
 // Kept below the weekly-starter equilibrium band so a fresh player is unpenalised

--- a/src/assets/js/Helpers.js
+++ b/src/assets/js/Helpers.js
@@ -130,14 +130,29 @@ export function fitnessTier(fitness) {
   return 'low';
 }
 
-// One week of fitness change for a player: a starter (played) first loses
-// FITNESS_MATCH_DRAIN, then he recovers FITNESS_REGEN_RATE of the gap back up
-// toward his stamina ceiling. Recovery only ever raises fitness — a match is the
-// only thing that lowers it — so a player who starts the season fresh above his
-// ceiling (see RESET_SEASON_STATS) stays there until he plays. A high-ceiling
-// player nets out about even on a match a week; a low-ceiling one slips and must
-// be rested. Bounded to [0, STAMINA_MAX].
-export function updateFitness(player, played) {
+// The fraction of his fitness gap a player recovers each week, scaled by his
+// conditioning (stamina): the best-conditioned third (stamina >=
+// FITNESS_REGEN_FULL_STAMINA) recover the whole gap — so they fully bounce back
+// from a match within a week — tapering down to FITNESS_REGEN_MIN at/below
+// FITNESS_REGEN_MIN_STAMINA for the least-conditioned, who keep carrying fatigue.
+export function fitnessRegenRate(stamina) {
+  const s = stamina ?? CFG.STAMINA_MAX;
+  const span = CFG.FITNESS_REGEN_FULL_STAMINA - CFG.FITNESS_REGEN_MIN_STAMINA;
+  const t = span > 0 ? (s - CFG.FITNESS_REGEN_MIN_STAMINA) / span : 1;
+  return clamp(CFG.FITNESS_REGEN_MIN + (1 - CFG.FITNESS_REGEN_MIN) * t, CFG.FITNESS_REGEN_MIN, 1);
+}
+
+// One week of fitness change for a player: he first loses `drain` (his actual
+// per-match fitness cost, accumulated minute by minute in the match engine — 0 on
+// a rest/training week), then recovers a conditioning-scaled fraction
+// (fitnessRegenRate) of the gap back up toward his stamina ceiling, capped at
+// FITNESS_RECOVER_MAX. Recovery only ever raises fitness — a match is the only
+// thing that lowers it — so a player who starts the season fresh above his ceiling
+// (see RESET_SEASON_STATS) stays there until he plays. The best-conditioned
+// recover fully from an average match, but the cap means an unlucky heavy-drain
+// match isn't erased in one week, so randomly even they may need a rest. Bounded
+// to [0, STAMINA_MAX].
+export function updateFitness(player, drain = 0) {
   // An injured player ignores normal drain/recovery: each weekly tick advances
   // his recovery by one week while his fitness stays pinned low. Once the (hidden)
   // drawn duration elapses the injury clears and fitness is restored part-way —
@@ -155,8 +170,10 @@ export function updateFitness(player, played) {
   }
   const ceiling = player.stamina ?? CFG.STAMINA_MAX;
   let fitness = player.fitness ?? ceiling;
-  if (played) fitness -= CFG.FITNESS_MATCH_DRAIN;
-  if (fitness < ceiling) fitness += (ceiling - fitness) * CFG.FITNESS_REGEN_RATE;
+  fitness -= drain;
+  if (fitness < ceiling) {
+    fitness += Math.min((ceiling - fitness) * fitnessRegenRate(ceiling), CFG.FITNESS_RECOVER_MAX);
+  }
   player.fitness = clamp(fitness, 0, CFG.STAMINA_MAX);
 }
 
@@ -192,7 +209,7 @@ function setSkill(player, exact) {
 //  - potential reverts gently toward its drawn value (bounds long-run drift).
 // All bounded to [0, 100]. Shared by the team and league APPLY/DEVELOP paths so
 // the own squad and every AI club develop identically.
-export function developPlayers(players, ratings = {}) {
+export function developPlayers(players, ratings = {}, drains = {}) {
   for (const player of players) {
     if (player.drawnPotential == null) player.drawnPotential = player.potential;
     if (player.skillExact == null) player.skillExact = player.skill;
@@ -220,8 +237,8 @@ export function developPlayers(players, ratings = {}) {
     );
     setSkill(player, clamp(player.skillExact + delta, 0, 100));
 
-    // Fitness recovers (and starters drain) once a week, on the same tick.
-    updateFitness(player, played);
+    // Fitness recovers (and drains by his actual per-match cost) once a week.
+    updateFitness(player, drains[player.id] ?? 0);
   }
 }
 

--- a/src/assets/js/MatchSim.js
+++ b/src/assets/js/MatchSim.js
@@ -346,6 +346,23 @@ export function simulateLiveMatch(home, away) {
   let homeGoals = 0;
   let awayGoals = 0;
 
+  // Per-player fitness drain, accumulated minute by minute for whoever is on the
+  // pitch (so it scales with minutes actually played). Each player gets one random
+  // per-match intensity, drawn lazily, plus fine per-minute noise on top.
+  const drain = {};
+  const intensity = {};
+  const drainOnPitch = (state) => {
+    for (const e of state.onPitch) {
+      const id = e.player.id;
+      if (out.has(id)) continue;
+      if (intensity[id] === undefined) {
+        intensity[id] = 1 + (Math.random() * 2 - 1) * CFG.FITNESS_DRAIN_INTENSITY_SPREAD;
+      }
+      const jitter = 1 + (Math.random() * 2 - 1) * CFG.FITNESS_DRAIN_MINUTE_JITTER;
+      drain[id] = (drain[id] || 0) + Math.max(0, CFG.FITNESS_DRAIN_PER_MINUTE * intensity[id] * jitter);
+    }
+  };
+
   for (let minute = 1; minute <= totalMinutes; minute++) {
     const homeChance = 2 * CFG.CHANCE_PER_MINUTE * strengthShare(homeEff, awayEff);
     const awayChance = 2 * CFG.CHANCE_PER_MINUTE * strengthShare(awayEff, homeEff);
@@ -371,8 +388,12 @@ export function simulateLiveMatch(home, away) {
     const awayManDown = runSideSubs(minute, 'away', awayState, out, events, contribs, awayInjured);
     homeEff *= Math.pow(CFG.RED_CARD_STRENGTH_FACTOR, homeManDown);
     awayEff *= Math.pow(CFG.RED_CARD_STRENGTH_FACTOR, awayManDown);
+
+    // Tire whoever ended the minute on the pitch (post-subs, excluding sent-off).
+    drainOnPitch(homeState);
+    drainOnPitch(awayState);
   }
-  return { totalMinutes, homeGoals, awayGoals, events, contribs };
+  return { totalMinutes, homeGoals, awayGoals, events, contribs, drain };
 }
 
 // Folds a timeline into per-player ratings for both sides, considering only
@@ -470,5 +491,6 @@ export function simulateInstant(home, away) {
     awayGoals: timeline.awayGoals,
     ratings: computeRatings(timeline, home, away),
     injuries: injuriesFromTimeline(timeline),
+    drain: timeline.drain,
   };
 }

--- a/src/store/League.js
+++ b/src/store/League.js
@@ -248,8 +248,8 @@ export const leagueModule = {
     // One week of development for every AI club squad (full squad, not just the
     // XI). The team module defines the same mutation for the own squad, so a
     // single commit('DEVELOP_WEEK') develops the whole league identically.
-    DEVELOP_WEEK(state, { ratings }) {
-      for (const club of state.clubs) HLP.developPlayers(club.players, ratings);
+    DEVELOP_WEEK(state, { ratings, drains }) {
+      for (const club of state.clubs) HLP.developPlayers(club.players, ratings, drains);
     },
 
     // Birthdays for the given week: AI players born this week age a year. Aging
@@ -350,16 +350,18 @@ export const leagueModule = {
 
       const ratings = {};
       const injuries = {};
+      const drains = {};
       const results = state.fixtures[matchday].map(({ home, away }) => {
         const outcome = playFixture(getters.matchSideById(home), getters.matchSideById(away));
         Object.assign(ratings, outcome.ratings);
         Object.assign(injuries, outcome.injuries || {});
+        Object.assign(drains, outcome.drain || {});
         return { home, away, homeGoals: outcome.homeGoals, awayGoals: outcome.awayGoals };
       });
       stampInjuries(injuries, rootState.club);
       commit('RECORD_MATCHDAY', { matchday, results });
       commit('APPLY_RATINGS', { ratings });
-      commit('DEVELOP_WEEK', { ratings });
+      commit('DEVELOP_WEEK', { ratings, drains });
       // Injuries are stamped after development so the injuring week pins the
       // player's fitness (overriding that week's match drain) and his recovery
       // clock starts next week; injured players are then moved to the reserve.
@@ -377,21 +379,24 @@ export const leagueModule = {
 
       const ratings = {};
       const injuries = {};
+      const drains = {};
       const results = state.fixtures[matchday].map(({ home, away }) => {
         if (home === null || away === null) {
           Object.assign(ratings, live.ratings || {});
           Object.assign(injuries, live.injuries || {});
+          Object.assign(drains, live.drain || {});
           return { home, away, homeGoals: live.homeGoals, awayGoals: live.awayGoals };
         }
         const outcome = playFixture(getters.matchSideById(home), getters.matchSideById(away));
         Object.assign(ratings, outcome.ratings);
         Object.assign(injuries, outcome.injuries || {});
+        Object.assign(drains, outcome.drain || {});
         return { home, away, homeGoals: outcome.homeGoals, awayGoals: outcome.awayGoals };
       });
       stampInjuries(injuries, rootState.club);
       commit('RECORD_MATCHDAY', { matchday, results });
       commit('APPLY_RATINGS', { ratings });
-      commit('DEVELOP_WEEK', { ratings });
+      commit('DEVELOP_WEEK', { ratings, drains });
       commit('APPLY_INJURIES', { injuries });
       commit('MOVE_INJURED_TO_RESERVE');
       return ratings;

--- a/src/store/Team.js
+++ b/src/store/Team.js
@@ -97,8 +97,8 @@ export const teamModule = {
     // reduced training weight). League defines the same mutation for AI clubs.
     // After developing, each player's weekly skill is logged (capped) so the
     // squad list can show the change over the last N weeks.
-    DEVELOP_WEEK(state, { ratings }) {
-      HLP.developPlayers(state.players, ratings);
+    DEVELOP_WEEK(state, { ratings, drains }) {
+      HLP.developPlayers(state.players, ratings, drains);
       for (const player of state.players) {
         if (!player.skillLog) player.skillLog = [];
         player.skillLog.push(player.skill);

--- a/src/views/MatchView.vue
+++ b/src/views/MatchView.vue
@@ -122,19 +122,21 @@ export default {
     },
 
     // Player id -> live fitness, draining from each starter's match-start value
-    // toward (start - FITNESS_MATCH_DRAIN) as the clock runs — this is in-match
-    // fatigue only. The weekly tick (updateFitness) afterwards recovers part of
-    // that drain, so the squad screens then show a higher, post-recovery value.
-    // Before kick-off this reads the stored value (fitness as of match start).
+    // toward (start - his rolled match drain) as the clock runs — this is in-match
+    // fatigue only, and the per-player drain is random (the engine's per-minute
+    // total), so they tire by different amounts. The weekly tick (updateFitness)
+    // afterwards recovers part of that drain, so the squad screens then show a
+    // higher value. Before kick-off this reads the stored match-start fitness.
     fitnessByPlayer() {
       const map = {};
       if (!this.match) return map;
       const frac = this.timeline && this.timeline.totalMinutes
         ? Math.min(1, this.minute / this.timeline.totalMinutes)
         : 0;
-      const drain = CFG.FITNESS_MATCH_DRAIN * frac;
+      const drainTotals = (this.timeline && this.timeline.drain) || {};
       for (const e of [...this.match.home.xi, ...this.match.away.xi]) {
         const start = e.player.fitness ?? CFG.STAMINA_MAX;
+        const drain = (drainTotals[e.player.id] || 0) * frac;
         map[e.player.id] = Math.max(0, start - drain);
       }
       return map;
@@ -309,6 +311,7 @@ export default {
         awayGoals: this.timeline.awayGoals,
         ratings: computeRatings(this.timeline, this.match.home, this.match.away),
         injuries: injuriesFromTimeline(this.timeline),
+        drain: this.timeline.drain,
       });
       this.$router.push({ name: 'League' });
     },

--- a/tests/fitness.test.js
+++ b/tests/fitness.test.js
@@ -5,6 +5,7 @@ import {
   fitnessFactor,
   fitnessTier,
   updateFitness,
+  fitnessRegenRate,
   agePlayer,
   developPlayers,
   aiSelectionSkill,
@@ -82,61 +83,111 @@ describe('fitnessTier', () => {
 });
 
 describe('updateFitness', () => {
-  it('drains a starter then recovers part of the gap', () => {
-    const p = { stamina: 88, fitness: 88 };
-    updateFitness(p, true);
-    // drains by FITNESS_MATCH_DRAIN, then recovers half the gap to the ceiling
-    expect(p.fitness).toBeCloseTo(88 - CFG.FITNESS_MATCH_DRAIN * (1 - CFG.FITNESS_REGEN_RATE), 5);
+  const DRAIN = CFG.FITNESS_MATCH_DRAIN; // an average full match's drain
+
+  it('fully recovers a top-third player from an average match (back to his ceiling)', () => {
+    const stam = CFG.FITNESS_REGEN_FULL_STAMINA; // top-third conditioning -> rate 1.0
+    const p = { stamina: stam, fitness: stam };
+    updateFitness(p, DRAIN);
+    expect(p.fitness).toBeCloseTo(stam, 5);
+  });
+
+  it('only partially recovers a played sub-threshold player (ceiling - drain*(1-rate))', () => {
+    const stam = 75; // below the top third -> rate < 1
+    const p = { stamina: stam, fitness: stam };
+    updateFitness(p, DRAIN);
+    const r = fitnessRegenRate(stam);
+    expect(r).toBeLessThan(1);
+    expect(p.fitness).toBeCloseTo(stam - DRAIN * (1 - r), 5);
+  });
+
+  it('caps weekly recovery, so a heavy-drain match leaves even a top player below his ceiling', () => {
+    const stam = 95;
+    const p = { stamina: stam, fitness: stam };
+    const heavy = CFG.FITNESS_RECOVER_MAX + 12; // exceeds the recovery cap
+    updateFitness(p, heavy);
+    expect(p.fitness).toBeCloseTo(stam - heavy + CFG.FITNESS_RECOVER_MAX, 5);
+    expect(p.fitness).toBeLessThan(stam); // can't bounce all the way back this week
   });
 
   it('leaves a fully-fit rested player at his ceiling', () => {
     const p = { stamina: 88, fitness: 88 };
-    updateFitness(p, false);
+    updateFitness(p, 0);
     expect(p.fitness).toBeCloseTo(88, 5);
   });
 
   it('recovers a rested, drained player toward his ceiling', () => {
-    const p = { stamina: 88, fitness: 40 };
-    updateFitness(p, false);
-    // 40 + (88 - 40) * 0.5 = 64
-    expect(p.fitness).toBeCloseTo(64, 5);
+    const p = { stamina: 75, fitness: 40 };
+    updateFitness(p, 0);
+    expect(p.fitness).toBeCloseTo(40 + (75 - 40) * fitnessRegenRate(75), 5);
+    expect(p.fitness).toBeGreaterThan(40);
   });
 
-  it('settles a weekly starter at a stable equilibrium (ceiling - drain)', () => {
-    const p = { stamina: 88, fitness: 88 - CFG.FITNESS_MATCH_DRAIN };
-    for (let i = 0; i < 30; i++) updateFitness(p, true);
-    expect(p.fitness).toBeCloseTo(88 - CFG.FITNESS_MATCH_DRAIN, 5);
+  it('settles a top-third weekly starter at his ceiling (full recovery from average matches)', () => {
+    const p = { stamina: 90, fitness: 90 };
+    for (let i = 0; i < 30; i++) updateFitness(p, DRAIN);
+    expect(p.fitness).toBeCloseTo(90, 5);
+  });
+
+  it('settles a weak weekly starter below his ceiling (must be rested)', () => {
+    const p = { stamina: 66, fitness: 66 };
+    for (let i = 0; i < 30; i++) updateFitness(p, DRAIN);
+    expect(p.fitness).toBeLessThan(CFG.FITNESS_TIER_OK + 5); // sinks toward the red band
   });
 
   it('keeps a strong player playable but pushes an overplayed weak one into the red', () => {
     const strong = { stamina: 95, fitness: 95 };
     const weak = { stamina: 62, fitness: 62 };
-    for (let i = 0; i < 30; i++) { updateFitness(strong, true); updateFitness(weak, true); }
+    for (let i = 0; i < 30; i++) { updateFitness(strong, DRAIN); updateFitness(weak, DRAIN); }
     expect(strong.fitness).toBeGreaterThan(CFG.FITNESS_TIER_OK); // a strong player stays playable (yellow)
     expect(weak.fitness).toBeLessThan(CFG.FITNESS_TIER_OK);      // an overplayed weak player drops into red
   });
 
   it('recovers toward but never past the ceiling', () => {
     const p = { stamina: 80, fitness: 50 };
-    for (let i = 0; i < 20; i++) updateFitness(p, false);
+    for (let i = 0; i < 20; i++) updateFitness(p, 0);
     expect(p.fitness).toBeLessThanOrEqual(80);
     expect(p.fitness).toBeCloseTo(80, 1); // converges up to the ceiling
   });
 
   it('keeps a season-fresh player above his ceiling until he plays', () => {
     const p = { stamina: 70, fitness: CFG.STAMINA_MAX }; // started the season fresh
-    updateFitness(p, false);
+    updateFitness(p, 0);
     expect(p.fitness).toBe(CFG.STAMINA_MAX); // recovery never pulls him down
-    updateFitness(p, true);                  // first match drains him
+    updateFitness(p, DRAIN);                 // first match drains him
     expect(p.fitness).toBeLessThan(CFG.STAMINA_MAX);
   });
 
   it('clamps to zero with a synthetic ceiling below the match drain', () => {
-    // Out-of-range ceiling (below FITNESS_MATCH_DRAIN) so the post-regen value
-    // would go negative — exercises the defensive lower clamp.
+    // Out-of-range ceiling (below the drain) so the post-regen value would go
+    // negative — exercises the defensive lower clamp.
     const p = { stamina: 10, fitness: 0 };
-    updateFitness(p, true); // 0 - 30 = -30, then + (10 - -30) * 0.5 = -10 -> clamp 0
+    updateFitness(p, DRAIN);
     expect(p.fitness).toBe(0);
+  });
+});
+
+describe('fitnessRegenRate', () => {
+  it('is full (1.0) at and above the top-third threshold', () => {
+    expect(fitnessRegenRate(CFG.FITNESS_REGEN_FULL_STAMINA)).toBeCloseTo(1, 5);
+    expect(fitnessRegenRate(CFG.STAMINA_MAX)).toBeCloseTo(1, 5);
+  });
+
+  it('floors at FITNESS_REGEN_MIN for the least-conditioned', () => {
+    expect(fitnessRegenRate(CFG.FITNESS_REGEN_MIN_STAMINA)).toBeCloseTo(CFG.FITNESS_REGEN_MIN, 5);
+    expect(fitnessRegenRate(CFG.FITNESS_REGEN_MIN_STAMINA - 20)).toBeCloseTo(CFG.FITNESS_REGEN_MIN, 5);
+  });
+
+  it('increases monotonically with stamina between the two anchors', () => {
+    const mid = fitnessRegenRate(76);
+    expect(fitnessRegenRate(70)).toBeLessThan(mid);
+    expect(mid).toBeLessThan(fitnessRegenRate(84));
+    expect(mid).toBeGreaterThan(CFG.FITNESS_REGEN_MIN);
+    expect(mid).toBeLessThan(1);
+  });
+
+  it('defaults a missing stamina to full recovery', () => {
+    expect(fitnessRegenRate(undefined)).toBeCloseTo(1, 5);
   });
 });
 
@@ -182,19 +233,20 @@ describe('developPlayers fitness pass', () => {
       id: 1, age: 28, optimalAge: 28, potential: 60, drawnPotential: 60,
       skill: 50, skillExact: 50, positions: { position: 'ST' },
       skills: { goalkeeping: 0, defense: 0, progression: 15, shot: 35 },
-      stamina: 88, fitness: 88, ...over,
+      // Sub-top-third conditioning, so playing leaves him short of full recovery.
+      stamina: 75, fitness: 75, ...over,
     };
   }
 
-  it('drains a player who featured this week', () => {
+  it('drains a player by his match drain when he featured this week', () => {
     const p = devPlayer();
-    developPlayers([p], { [p.id]: 6.5 });
-    expect(p.fitness).toBeLessThan(88);
+    developPlayers([p], { [p.id]: 6.5 }, { [p.id]: CFG.FITNESS_MATCH_DRAIN });
+    expect(p.fitness).toBeLessThan(75);
   });
 
-  it('recovers a rested, drained player', () => {
+  it('recovers a rested player (no drain entry) toward his ceiling', () => {
     const p = devPlayer({ fitness: 50 });
-    developPlayers([p], {});
+    developPlayers([p], {}, {});
     expect(p.fitness).toBeGreaterThan(50);
   });
 });
@@ -252,6 +304,19 @@ describe('low fitness hurts match performance', () => {
     // Away attackers and keeper are fresh in both runs, so the extra goals come
     // from the fitness malus on the defenders specifically (D term + targeting).
     expect(homeGoalsVs(20)).toBeGreaterThan(homeGoalsVs(100));
+  });
+
+  it('accrues a per-player match drain that varies and is in the nominal ballpark', () => {
+    const home = side(55, 100), away = side(55, 100);
+    const tl = simulateLiveMatch(home, away);
+    const starters = [...home.xi, ...away.xi];
+    const drains = starters.map(e => tl.drain[e.player.id]);
+    for (const d of drains) expect(d).toBeGreaterThan(0); // everyone on the pitch tires
+    const avg = drains.reduce((s, d) => s + d, 0) / drains.length;
+    expect(avg).toBeGreaterThan(CFG.FITNESS_MATCH_DRAIN * 0.6);
+    expect(avg).toBeLessThan(CFG.FITNESS_MATCH_DRAIN * 1.5);
+    // per-player intensity makes the totals differ (not a flat constant)
+    expect(Math.max(...drains) - Math.min(...drains)).toBeGreaterThan(2);
   });
 });
 

--- a/tests/injuries.test.js
+++ b/tests/injuries.test.js
@@ -36,28 +36,28 @@ describe('updateFitness recovery for an injured player', () => {
 
   it('pins fitness low and counts elapsed up while recovering', () => {
     const p = injured(3);
-    updateFitness(p, false);
+    updateFitness(p, 0);
     expect(p.injury.elapsed).toBe(1);
     expect(p.fitness).toBe(CFG.INJURY_FITNESS_INJURED);
     expect(p.injury).not.toBeNull();
   });
 
-  it('takes no match drain even when the player is marked as having played', () => {
+  it('takes no match drain even when handed a full match drain', () => {
     const p = injured(3);
-    updateFitness(p, true);
+    updateFitness(p, CFG.FITNESS_MATCH_DRAIN);
     expect(p.fitness).toBe(CFG.INJURY_FITNESS_INJURED); // not 20 - FITNESS_MATCH_DRAIN
   });
 
   it('clears the injury and restores partial fitness once the duration elapses', () => {
     const p = injured(2, 1); // one week already recovered
-    updateFitness(p, false);  // -> elapsed 2 == weeks
+    updateFitness(p, 0);  // -> elapsed 2 == weeks
     expect(p.injury).toBeNull();
     expect(p.fitness).toBe(CFG.INJURY_FITNESS_RECOVERED);
   });
 
   it('a one-week injury clears on the next recovery tick', () => {
     const p = injured(1);
-    updateFitness(p, false);
+    updateFitness(p, 0);
     expect(p.injury).toBeNull();
     expect(p.fitness).toBe(CFG.INJURY_FITNESS_RECOVERED);
   });


### PR DESCRIPTION
## Summary
Two related fitness-balance changes.

**Conditioning-scaled recovery.** Weekly recovery now scales with `stamina`: the best-conditioned third (stamina ≥ `FITNESS_REGEN_FULL_STAMINA`) recover the whole gap each week and fully bounce back from an average match, tapering down to `FITNESS_REGEN_MIN` for the least-conditioned, who keep carrying fatigue. Lifts recovery across the board (fitness no longer stays down too much) while the weak/old still need resting.

**Randomized per-minute match drain.** Drain is accumulated minute by minute in the match engine instead of a flat constant: each on-pitch player loses `FITNESS_DRAIN_PER_MINUTE`, scaled by a random per-player per-match intensity (±35%) plus fine per-minute noise. So the per-player total **varies** (some matches take more out of you), **scales with minutes actually played** (a substitute drains less), and is threaded from the sim through the matchday actions into the weekly `updateFitness`.

Weekly recovery is capped at `FITNESS_RECOVER_MAX`, so an unlucky heavy-drain match isn't fully erased in one week — that's what lets randomly any player, even a fit one, occasionally need a rest. The live match view drains each starter toward his own rolled total.

All constants live in `Config.js` (`STAMINA_*` = ceiling generation, `FITNESS_*` = current-value dynamics).

## Testing
- 167/167 tests pass (`tests/fitness.test.js`, `tests/injuries.test.js` updated; added: conditioning-scaled `fitnessRegenRate`, recovery cap, per-player drain variance, drain threading). Production build clean.
- Browser-verified against the real bundle: the engine returns a varied per-player drain (18.5–39.8, avg ~28); a simulated matchday left the squad with distinct fitness values, top-third normal-drain players fully recovered, sub-threshold players carried fatigue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)